### PR TITLE
[codex] optimize speed and refresh benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `pymini` is an AST-based Python minifier for scripts and packages. It preserves
 package layout by default, can emit a single-file bundle when asked, and can
-shrink Python code by roughly `30%` to `90%` depending on the codebase and
-whether you compare raw source or compressed archives.
+shrink Python code by roughly `15%` to `70%` on the checked-in fixtures and
+validated package benchmarks.
 
 - [Getting Started](#getting-started)
 - [Installation](#installation)
@@ -46,7 +46,7 @@ Current checked-in fixtures:
 | `tests/examples/pyminifier.py` | `1,355` bytes | `511` bytes | `62.3%` |
 | `tests/examples/pyminify.py` | `1,990` bytes | `981` bytes | `50.7%` |
 | `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `33,107` bytes | `66.3%` |
-| `TexSoup/` compressed source (`.tar.gz`) | `70,532` bytes | `11,850` bytes | `83.2%` |
+| `TexSoup/` compressed source (`.tar.gz`) | `23,118` bytes | `11,368` bytes | `50.8%` |
 
 For baseline comparisons, speed results, and TexSoup validation details, see
 [benchmarks/README.md](./benchmarks/README.md).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,47 +3,26 @@
 This directory holds the current size and speed measurements for `pymini`, plus
 the benchmark harness used to reproduce them.
 
-- [Compression](#compression)
-- [Speed](#speed)
+- [Results](#results)
+- [Reproduce](#reproduce)
 - [TexSoup Validation](#texsoup-validation)
 
-# Compression
+# Results
 
-Checked-in fixture comparison:
+| Input | Original | `pymini` size | `pymini` speed | `pyminifier` size | `pyminifier` speed | `python-minifier` size | `python-minifier` speed |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `pyminifier.py` | `1,355` bytes | `511` bytes, `62.3%` | `2.4 ms` | `676` bytes, `50.1%` | `0.4 ms` | `1,020` bytes, `24.7%` | `1.6 ms` |
+| `pyminify.py` | `1,990` bytes | `981` bytes, `50.7%` | `5.4 ms` | `1,605` bytes, `19.3%` | `1.2 ms` | `983` bytes, `50.6%` | `4.1 ms` |
+| `TexSoup/*.py` | `98,181` bytes | `33,107` bytes, `66.3%` | `399.3 ms` | `34,643` bytes, `64.7%` | `31.3 ms` | `83,303` bytes, `15.2%` | `120.8 ms` |
+| `TexSoup.tar.gz` | `23,118` bytes | `11,368` bytes, `50.8%` | `—` | `9,741` bytes, `57.9%` | `—` | `21,532` bytes, `6.9%` | `—` |
 
-| Input | Original | `pymini` | `pyminifier` | `python-minifier` |
-| --- | ---: | ---: | ---: | ---: |
-| `tests/examples/pyminifier.py` | `1,355` bytes | `511` bytes, `62.3%` | `676` bytes, `50.1%` | `1,020` bytes, `24.7%` |
-| `tests/examples/pyminify.py` | `1,990` bytes | `981` bytes, `50.7%` | `1,605` bytes, `19.3%` | `983` bytes, `50.6%` |
+`TexSoup/*.py` compares validated package outputs. `pymini` uses package mode;
+the baselines minify each file independently in the preserved package tree. All
+three outputs pass the upstream TexSoup test suite (`78` tests).
 
-TexSoup package mode (`pymini` only):
+# Reproduce
 
-| Input | Original | `pymini` | Reduction |
-| --- | ---: | ---: | ---: |
-| `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `33,107` bytes | `66.3%` |
-| `TexSoup/` compressed source (`.tar.gz`) | `70,532` bytes | `11,850` bytes | `83.2%` |
-
-TexSoup file-by-file package comparison. All three outputs pass the upstream
-TexSoup test suite (`78` tests):
-
-| Input | Original | `pymini` | `pyminifier` | `python-minifier` |
-| --- | ---: | ---: | ---: | ---: |
-| `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `32,131` bytes, `67.3%` | `34,643` bytes, `64.7%` | `83,303` bytes, `15.2%` |
-| `TexSoup/` compressed source (`.tar.gz`) | `23,116` bytes | `10,926` bytes, `52.7%` | `9,741` bytes, `57.9%` | `21,532` bytes, `6.9%` |
-
-# Speed
-
-Latency is machine-dependent. Recompute these with
-`PYTHONPATH=. .venv/bin/python benchmarks/benchmark_speed.py`.
-
-| Input | `pymini` | `pyminifier` | `python-minifier` |
-| --- | ---: | ---: | ---: |
-| `tests/examples/pyminifier.py` | `2.5 ms` | `0.4 ms` | `1.6 ms` |
-| `tests/examples/pyminify.py` | `5.7 ms` | `1.2 ms` | `4.2 ms` |
-| `TexSoup/` package API | `410.4 ms` | `—` | `—` |
-| `TexSoup/` package CLI | `414.0 ms` | `—` | `—` |
-
-To reproduce those numbers:
+Recompute the speed measurements with:
 
 ```bash
 python3 -m pip install -e ".[dev]" python-minifier
@@ -56,9 +35,9 @@ PYTHONPATH=. .venv/bin/python benchmarks/benchmark_speed.py --pyminifier-root /t
 `pymini` has been validated against the upstream `TexSoup` test suite in
 package mode. Current validation: upstream pytest passes (`78` tests), raw
 source code is `66.3%` smaller, and compressed source code (`.tar.gz`) is
-`83.2%` smaller.
+`50.8%` smaller when measured on clean `.py`-only package snapshots.
 
-<!-- Raw bytes: 98,181 -> 33,107. Compressed bytes: 70,532 -> 11,850. -->
+<!-- Raw bytes: 98,181 -> 33,107. Compressed bytes: 23,118 -> 11,368. -->
 
 To reproduce that flow locally:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,12 +16,20 @@ Checked-in fixture comparison:
 | `tests/examples/pyminifier.py` | `1,355` bytes | `511` bytes, `62.3%` | `676` bytes, `50.1%` | `1,020` bytes, `24.7%` |
 | `tests/examples/pyminify.py` | `1,990` bytes | `981` bytes, `50.7%` | `1,605` bytes, `19.3%` | `983` bytes, `50.6%` |
 
-TexSoup package validation:
+TexSoup package mode (`pymini` only):
 
 | Input | Original | `pymini` | Reduction |
 | --- | ---: | ---: | ---: |
 | `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `33,107` bytes | `66.3%` |
 | `TexSoup/` compressed source (`.tar.gz`) | `70,532` bytes | `11,850` bytes | `83.2%` |
+
+TexSoup file-by-file package comparison. All three outputs pass the upstream
+TexSoup test suite (`78` tests):
+
+| Input | Original | `pymini` | `pyminifier` | `python-minifier` |
+| --- | ---: | ---: | ---: | ---: |
+| `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `32,131` bytes, `67.3%` | `34,643` bytes, `64.7%` | `83,303` bytes, `15.2%` |
+| `TexSoup/` compressed source (`.tar.gz`) | `23,116` bytes | `10,926` bytes, `52.7%` | `9,741` bytes, `57.9%` | `21,532` bytes, `6.9%` |
 
 # Speed
 
@@ -30,10 +38,10 @@ Latency is machine-dependent. Recompute these with
 
 | Input | `pymini` | `pyminifier` | `python-minifier` |
 | --- | ---: | ---: | ---: |
-| `tests/examples/pyminifier.py` | `14.1 ms` | `0.4 ms` | `1.5 ms` |
-| `tests/examples/pyminify.py` | `1227.6 ms` | `1.1 ms` | `4.0 ms` |
-| `TexSoup/` package API | `4928.8 ms` | `—` | `—` |
-| `TexSoup/` package CLI | `5062.0 ms` | `—` | `—` |
+| `tests/examples/pyminifier.py` | `2.5 ms` | `0.4 ms` | `1.6 ms` |
+| `tests/examples/pyminify.py` | `5.7 ms` | `1.2 ms` | `4.2 ms` |
+| `TexSoup/` package API | `410.4 ms` | `—` | `—` |
+| `TexSoup/` package CLI | `414.0 ms` | `—` | `—` |
 
 To reproduce those numbers:
 

--- a/pymini/pymini.py
+++ b/pymini/pymini.py
@@ -117,7 +117,7 @@ class ParentSetter(NodeTransformer):
         for child in ast.iter_child_nodes(node):
             child.parent = node
             self.visit(child)
-        return super().visit(node)
+        return node
 
 
 class CommentRemover(NodeTransformer):
@@ -845,7 +845,6 @@ class FusedVariableShortener(Transformer):
             )
             imported.transform(tree)
             append_public_aliases(tree, imported.nodes_to_append)
-            ParentSetter().visit(tree)
             new_trees.append(tree)
         return new_trees
 
@@ -918,8 +917,6 @@ class RepeatedStringHoister(Transformer):
             collector = RepeatedStringCollector()
             collector.visit(tree)
             RepeatedStringRewriter(self.generator, collector.repeated_strings_by_scope).visit(tree)
-            ParentSetter().visit(tree)
-            ast.fix_missing_locations(tree)
         return trees
 
 
@@ -1080,10 +1077,7 @@ class RepeatedNameAliaser(ast.NodeTransformer):
 
     def transform(self, *trees):
         for tree in trees:
-            ParentSetter().visit(tree)
             self.visit(tree)
-            ParentSetter().visit(tree)
-            ast.fix_missing_locations(tree)
         return trees
 
     def _next_safe_name(self, reserved_names):
@@ -1350,6 +1344,13 @@ class Unparser:
     def transform(self, *trees):
         for tree in trees:
             yield ast.unparse(tree)
+
+
+class LocationFixer(Transformer):
+    def transform(self, *trees):
+        for tree in trees:
+            ast.fix_missing_locations(tree)
+        return trees
 
 
 def module_prefixes(module: Optional[str]) -> List[str]:
@@ -1727,6 +1728,7 @@ def minify(sources, modules='main', keep_module_names=False,
         ),
 
         # final post-processing to remove whitespace (minify)
+        LocationFixer(),
         Unparser(),
         WhitespaceRemover(),
     )


### PR DESCRIPTION
## Summary
- remove redundant AST traversals and location-fix passes from the hot minification path
- keep minified output semantics intact while cutting fixture and package latency substantially
- refresh the benchmark docs with corrected `.tar.gz` numbers, validated TexSoup baseline comparisons, and a consolidated results table

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest`
- `PYTHONPATH=/private/tmp/pymini-texsoup-testtarget:/private/tmp/pymini-texsoup-repo/tests .venv/bin/python -m pytest /private/tmp/pymini-texsoup-repo/tests -o addopts=''`
- `PYTHONPATH=. .venv/bin/python benchmarks/benchmark_speed.py --pyminifier-root /private/tmp/pymini-pyminifier-src/pyminifier-2.1`
- validated file-by-file TexSoup outputs for `pyminifier` and `python-minifier` against the upstream `78`-test suite
