### PR TITLE
[codex] refresh local scope naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Current checked-in fixtures, using
 | --- | ---: | ---: | ---: |
 | `tests/examples/pyminifier.py` | `1,355` bytes | `438` bytes | `67.7%` |
 | `tests/examples/pyminify.py` | `1,990` bytes | `935` bytes | `53.0%` |
-| `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `24,722` bytes | `74.8%` |
-| `TexSoup/` compressed source (`.tar.gz`) | `23,656` bytes | `9,208` bytes | `61.1%` |
+| `TexSoup/` raw Python source (`*.py`) | `98,181` bytes | `24,288` bytes | `75.3%` |
+| `TexSoup/` compressed source (`.tar.gz`) | `23,101` bytes | `8,363` bytes | `63.8%` |
 
 For baseline comparisons, speed results, and TexSoup validation details, see
 [benchmarks/README.md](./benchmarks/README.md).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,10 +11,10 @@ the benchmark harness used to reproduce them.
 
 | Input | Original | `pymini` size | `pymini` speed | `pyminifier` size | `pyminifier` speed | `python-minifier` size | `python-minifier` speed |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `pyminifier.py` | `1,355` bytes | `438` bytes, `67.7%` | `1.9 ms` | `611` bytes, `54.9%` | `0.4 ms` | `1,020` bytes, `24.7%` | `1.6 ms` |
-| `pyminify.py` | `1,990` bytes | `935` bytes, `53.0%` | `5.4 ms` | `1,540` bytes, `22.6%` | `1.3 ms` | `983` bytes, `50.6%` | `4.1 ms` |
-| `TexSoup/*.py` | `98,181` bytes | `24,722` bytes, `74.8%` | `175.6 ms` | `34,643` bytes, `64.7%` | `28.0 ms` | `83,303` bytes, `15.2%` | `118.3 ms` |
-| `TexSoup.tar.gz` | `23,656` bytes | `9,208` bytes, `61.1%` | `175.6 ms` | `9,725` bytes, `58.9%` | `28.0 ms` | `21,509` bytes, `9.1%` | `118.3 ms` |
+| `pyminifier.py` | `1,355` bytes | `438` bytes, `67.7%` | `2.1 ms` | `611` bytes, `54.9%` | `0.4 ms` | `1,020` bytes, `24.7%` | `1.7 ms` |
+| `pyminify.py` | `1,990` bytes | `935` bytes, `53.0%` | `5.9 ms` | `1,540` bytes, `22.6%` | `1.2 ms` | `983` bytes, `50.6%` | `4.3 ms` |
+| `TexSoup/*.py` | `98,181` bytes | `24,288` bytes, `75.3%` | `127.5 ms` | `34,643` bytes, `64.7%` | `29.7 ms` | `83,303` bytes, `15.2%` | `123.6 ms` |
+| `TexSoup.tar.gz` | `23,101` bytes | `8,363` bytes, `63.8%` | `127.5 ms` | `9,718` bytes, `57.9%` | `29.7 ms` | `21,497` bytes, `6.9%` | `123.6 ms` |
 
 `pymini` is benchmarked with `--rename-modules --rename-global-variables --rename-arguments`.
 `TexSoup/*.py` compares validated package outputs. `pymini` uses package mode;
@@ -38,10 +38,10 @@ PYTHONPATH=. .venv/bin/python benchmarks/benchmark_speed.py --pyminifier-root /t
 `pymini` has been validated against the upstream `TexSoup` test suite in
 package mode with `--rename-modules --rename-global-variables --rename-arguments`.
 Current validation: upstream pytest passes (`78` tests), raw source code is
-`74.8%` smaller, and compressed source code (`.tar.gz`) is `61.1%` smaller
+`75.3%` smaller, and compressed source code (`.tar.gz`) is `63.8%` smaller
 when measured on clean `.py`-only package snapshots.
 
-<!-- Raw bytes: 98,181 -> 24,722. Compressed bytes: 23,656 -> 9,208. -->
+<!-- Raw bytes: 98,181 -> 24,288. Compressed bytes: 23,101 -> 8,363. -->
 
 To reproduce that flow locally:
 

--- a/examples/pyminifier.py
+++ b/examples/pyminifier.py
@@ -7,4 +7,4 @@ class Foo(object):
  def __init__(self,*args,**kwargs):0
  def demiurgic_mystificator(self,dactyl):c=a.palpitation(dactyl);return b.dark_voodoo(c)
  def test(self,whatever):print(whatever)
-if __name__=='__main__':print('Forming...');d=Foo('epicaricacy','perseverate');d.test('Codswallop')
+if __name__=='__main__':print('Forming...');c=Foo('epicaricacy','perseverate');c.test('Codswallop')

--- a/examples/pyminify.py
+++ b/examples/pyminify.py
@@ -1,23 +1,23 @@
 def a(event,context):
- e='RequestType';f='PhysicalResourceId';g='None';h='Status';i='SUCCESS';j='Tags';k='OldResourceProperties';l.info(event);m,n,o,p,q,r,s,t,u=(event,create_cert,add_tags,validate,wait_for_issuance,context,send,reinvoke,acm)
+ c='RequestType';d='PhysicalResourceId';e='None';f='Status';g='SUCCESS';h='Tags';i='OldResourceProperties';l.info(event);j,k,m,n,o,p,q,r,s=(event,create_cert,add_tags,validate,wait_for_issuance,context,send,reinvoke,acm)
  try:
-  b=hashlib.new('md5',(m['RequestId']+m['StackId']).encode()).hexdigest();c=m['ResourceProperties']
-  if m[e]=='Create':
-   m[f]=g;m[f]=n(c,b);o(m[f],c);p(m[f],c)
-   if q(m[f],r):m[h]=i;return s(m)
-   else:return t(m,r)
-  elif m[e]=='Delete':
-   if m[f]!=g:u.delete_certificate(CertificateArn=m[f])
-   m[h]=i;return s(m)
-  elif m[e]=='Update':
-   if replace_cert(m):
-    m[f]=n(c,b);o(m[f],c);p(m[f],c)
-    if not q(m[f],r):return t(m,r)
+  a=hashlib.new('md5',(j['RequestId']+j['StackId']).encode()).hexdigest();b=j['ResourceProperties']
+  if j[c]=='Create':
+   j[d]=e;j[d]=k(b,a);m(j[d],b);n(j[d],b)
+   if o(j[d],p):j[f]=g;return q(j)
+   else:return r(j,p)
+  elif j[c]=='Delete':
+   if j[d]!=e:s.delete_certificate(CertificateArn=j[d])
+   j[f]=g;return q(j)
+  elif j[c]=='Update':
+   if replace_cert(j):
+    j[d]=k(b,a);m(j[d],b);n(j[d],b)
+    if not o(j[d],p):return r(j,p)
    else:
-    if j in m[k]:u.remove_tags_from_certificate(CertificateArn=m[f],Tags=m[k][j])
-    o(m[f],c)
-   m[h]=i;return s(m)
+    if h in j[i]:s.remove_tags_from_certificate(CertificateArn=j[d],Tags=j[i][h])
+    m(j[d],b)
+   j[f]=g;return q(j)
   else:raise RuntimeError('Unknown RequestType')
- except Exception as d:l.exception('');m[h]='FAILED';m['Reason']=str(d);return s(m)
- del (m,n,o,p,q,r,s,t,u)
+ except Exception as b:l.exception('');j[f]='FAILED';j['Reason']=str(b);return q(j)
+ del (j,k,m,n,o,p,q,r,s)
 handler=a

--- a/pymini/pymini.py
+++ b/pymini/pymini.py
@@ -99,6 +99,105 @@ class VariableNameCollector(NodeVisitor):
         self.names.add(node.id)
 
 
+class ScopeLocalNameCollector(ast.NodeVisitor):
+    def __init__(self):
+        self.reserved_names = set()
+        self.bindings = set()
+        self.loads = set()
+
+    def visit_Name(self, node):
+        self.reserved_names.add(node.id)
+        if isinstance(node.ctx, ast.Store):
+            self.bindings.add(node.id)
+        elif isinstance(node.ctx, ast.Load):
+            self.loads.add(node.id)
+
+    def visit_arg(self, node):
+        self.reserved_names.add(node.arg)
+        self.bindings.add(node.arg)
+        if node.annotation is not None:
+            self.visit(node.annotation)
+
+    def visit_Global(self, node):
+        self.reserved_names.update(node.names)
+
+    visit_Nonlocal = visit_Global
+
+    def visit_ExceptHandler(self, node):
+        if node.name:
+            self.reserved_names.add(node.name)
+            self.bindings.add(node.name)
+        if node.type is not None:
+            self.visit(node.type)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            bound_name = alias.asname or alias.name.split(".", 1)[0]
+            self.reserved_names.add(bound_name)
+            self.bindings.add(bound_name)
+
+    def visit_ImportFrom(self, node):
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            bound_name = alias.asname or alias.name
+            self.reserved_names.add(bound_name)
+            self.bindings.add(bound_name)
+
+    def _visit_nested_function(self, node):
+        self.reserved_names.add(node.name)
+        self.bindings.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in node.args.defaults:
+            self.visit(default)
+        for default in node.args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+        for argument in (
+            [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+            + ([node.args.vararg] if node.args.vararg is not None else [])
+            + ([node.args.kwarg] if node.args.kwarg is not None else [])
+        ):
+            if argument is not None and argument.annotation is not None:
+                self.visit(argument.annotation)
+        returns = getattr(node, "returns", None)
+        if returns is not None:
+            self.visit(returns)
+
+    def visit_FunctionDef(self, node):
+        self._visit_nested_function(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node):
+        self.reserved_names.add(node.name)
+        self.bindings.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+
+    def visit_Lambda(self, node):
+        return None
+
+    def visit_ListComp(self, node):
+        return None
+
+    def visit_SetComp(self, node):
+        return None
+
+    def visit_DictComp(self, node):
+        return None
+
+    def visit_GeneratorExp(self, node):
+        return None
+
+
 class ParentSetter(NodeTransformer):
     """Adds parent attribute to each node.
     
@@ -192,6 +291,7 @@ class VariableShortener(NodeTransformer):
         self.nodes_to_append = []
         self.public_global_names = set()
         self.scope_stack = []
+        self.local_rename_scopes = []
         self.class_context_stack = []
         self.class_member_mappings = {}
         self.callable_argument_infos = {}
@@ -215,6 +315,26 @@ class VariableShortener(NodeTransformer):
                     self.mapping_values.add(candidate)
                     break
         return self.mapping[old_name]
+
+    def _lookup_local_identifier(self, old_name):
+        for scope in reversed(self.local_rename_scopes):
+            if old_name in scope["mapping"]:
+                return scope["mapping"][old_name]
+        return None
+
+    def _lookup_visible_identifier(self, old_name):
+        local_name = self._lookup_local_identifier(old_name)
+        if local_name is not None:
+            return local_name
+        return self.mapping.get(old_name)
+
+    def _rename_local_identifier(self, old_name):
+        scope = self.local_rename_scopes[-1]
+        if old_name not in scope["mapping"]:
+            new_name = next(scope["generator"])
+            scope["mapping"][old_name] = new_name
+            scope["used_names"].add(new_name)
+        return scope["mapping"][old_name]
 
     def _append_public_alias(self, old_name, new_name):
         if old_name != new_name:
@@ -379,7 +499,7 @@ class VariableShortener(NodeTransformer):
             old_name = argument.arg
             if not self._should_rename_argument(old_name):
                 continue
-            new_name = self._rename_identifier(old_name)
+            new_name = self._rename_local_identifier(old_name)
             argument.arg = new_name
             if old_name != new_name:
                 argument_mapping[old_name] = new_name
@@ -448,6 +568,14 @@ class VariableShortener(NodeTransformer):
     def _rename_assignment_target(self, target, create_new=True):
         if isinstance(target, ast.Name):
             if self._is_active_parameter_name(target.id) or self._preserve_function_name(target.id):
+                return
+            if (
+                self.local_rename_scopes
+                and self.scope_stack
+                and target.id in self.scope_stack[-1]["bindings"]
+                and target.id not in self.scope_stack[-1]["globals"]
+            ):
+                target.id = self._rename_local_identifier(target.id)
                 return
             if target.id in self.mapping:
                 target.id = self.mapping[target.id]
@@ -566,6 +694,23 @@ class VariableShortener(NodeTransformer):
             if name in scope["bindings"]:
                 return name in scope["args"]
         return False
+
+    def _local_scope_state(self, node):
+        collector = ScopeLocalNameCollector()
+        collector.visit(node.args)
+        for statement in getattr(node, "body", []):
+            collector.visit(statement)
+        reserved_names = set(collector.reserved_names)
+        for name in collector.loads - collector.bindings:
+            visible_name = self._lookup_visible_identifier(name)
+            if visible_name is not None:
+                reserved_names.add(visible_name)
+        used_names = set(reserved_names)
+        return {
+            "mapping": {},
+            "used_names": used_names,
+            "generator": variable_name_generator(used_names),
+        }
 
     def _visit_ImportOrImportFrom(self, node):
         """Shorten imported library names.
@@ -705,6 +850,7 @@ class VariableShortener(NodeTransformer):
         old_name = node.name
         if self._preserve_function_name(node.name):
             self.scope_stack.append(self._scope_bindings(node))
+            self.local_rename_scopes.append(self._local_scope_state(node))
             try:
                 argument_info = self._rename_function_arguments(node)
                 class_context = self._current_class_context()
@@ -712,6 +858,7 @@ class VariableShortener(NodeTransformer):
                     class_context["receiver_names"].update(argument_info["receiver_names"])
                 return self.generic_visit(node)
             finally:
+                self.local_rename_scopes.pop()
                 self.scope_stack.pop()
         if self._is_method_definition(node):
             class_context = self._current_class_context()
@@ -732,6 +879,7 @@ class VariableShortener(NodeTransformer):
                         self._generated_assignment(f"{old_name} = {node.name}")
                     )
             self.scope_stack.append(self._scope_bindings(node))
+            self.local_rename_scopes.append(self._local_scope_state(node))
             try:
                 argument_info = self._rename_function_arguments(node)
                 if class_context is not None:
@@ -745,26 +893,31 @@ class VariableShortener(NodeTransformer):
                         class_context["argument_infos"][node.name] = copied
                 return self.generic_visit(node)
             finally:
+                self.local_rename_scopes.pop()
                 self.scope_stack.pop()
         if self.keep_global_variables and self._is_node_global(node):
             if len(node.name) > 1 and node.name not in self.mapping_values:
                 node.name = self._rename_identifier(old_name)
                 self._append_public_alias(old_name, node.name)
             self.scope_stack.append(self._scope_bindings(node))
+            self.local_rename_scopes.append(self._local_scope_state(node))
             try:
                 argument_info = self._rename_function_arguments(node)
                 self._record_callable_argument_info(old_name, node.name, argument_info)
                 return self.generic_visit(node)
             finally:
+                self.local_rename_scopes.pop()
                 self.scope_stack.pop()
         if node.name not in self.mapping_values:
             node.name = self._rename_identifier(node.name)
         self.scope_stack.append(self._scope_bindings(node))
+        self.local_rename_scopes.append(self._local_scope_state(node))
         try:
             argument_info = self._rename_function_arguments(node)
             self._record_callable_argument_info(old_name, node.name, argument_info)
             return self.generic_visit(node)
         finally:
+            self.local_rename_scopes.pop()
             self.scope_stack.pop()
 
     visit_AsyncFunctionDef = visit_FunctionDef
@@ -923,6 +1076,10 @@ class VariableShortener(NodeTransformer):
         """
         if node.id in self.mapping_values:
             return node
+        local_name = self._lookup_local_identifier(node.id)
+        if local_name is not None:
+            node.id = local_name
+            return self.generic_visit(node)
         if self._is_preserved_function_parameter_reference(node):
             return self.generic_visit(node)
         if self._is_in_expression_scope(node):

--- a/pymini/pymini.py
+++ b/pymini/pymini.py
@@ -292,6 +292,7 @@ class VariableShortener(NodeTransformer):
         self.public_global_names = set()
         self.scope_stack = []
         self.local_rename_scopes = []
+        self.instance_type_scopes = [{}]
         self.class_context_stack = []
         self.class_member_mappings = {}
         self.callable_argument_infos = {}
@@ -329,12 +330,33 @@ class VariableShortener(NodeTransformer):
         return self.mapping.get(old_name)
 
     def _rename_local_identifier(self, old_name):
+        if old_name in self.mapping_values:
+            return old_name
         scope = self.local_rename_scopes[-1]
         if old_name not in scope["mapping"]:
             new_name = next(scope["generator"])
             scope["mapping"][old_name] = new_name
             scope["used_names"].add(new_name)
         return scope["mapping"][old_name]
+
+    def _push_instance_scope(self):
+        self.instance_type_scopes.append({})
+
+    def _pop_instance_scope(self):
+        self.instance_type_scopes.pop()
+
+    def _set_instance_type(self, name, class_name):
+        scope = self.instance_type_scopes[-1]
+        if class_name is None:
+            scope.pop(name, None)
+        else:
+            scope[name] = class_name
+
+    def _lookup_instance_type(self, name):
+        for scope in reversed(self.instance_type_scopes):
+            if name in scope:
+                return scope[name]
+        return None
 
     def _append_public_alias(self, old_name, new_name):
         if old_name != new_name:
@@ -530,16 +552,21 @@ class VariableShortener(NodeTransformer):
         if not isinstance(func, ast.Attribute):
             return None
         base_name = func.value.id if isinstance(func.value, ast.Name) else None
-        if base_name is None:
-            return None
         class_context = self._current_class_context()
-        if class_context is not None and base_name in (
-            class_context["receiver_names"]
-            | {class_context["old_name"], class_context["new_name"]}
-        ):
-            return class_context["argument_infos"].get(func.attr)
-        if base_name in self.class_method_argument_infos:
-            return self.class_method_argument_infos[base_name].get(func.attr)
+        if base_name is not None:
+            if class_context is not None and base_name in (
+                class_context["receiver_names"]
+                | {class_context["old_name"], class_context["new_name"]}
+            ):
+                return class_context["argument_infos"].get(func.attr)
+            instance_class = self._lookup_instance_type(base_name)
+            if instance_class in self.class_method_argument_infos:
+                return self.class_method_argument_infos[instance_class].get(func.attr)
+            if base_name in self.class_method_argument_infos:
+                return self.class_method_argument_infos[base_name].get(func.attr)
+        receiver_class = self._receiver_class_name(func.value)
+        if receiver_class in self.class_method_argument_infos:
+            return self.class_method_argument_infos[receiver_class].get(func.attr)
         return None
 
     def _rewrite_keywords_as_positional(self, node, argument_info):
@@ -686,13 +713,15 @@ class VariableShortener(NodeTransformer):
         return False
 
     def _is_active_parameter_name(self, name):
-        if self.rename_arguments:
-            return False
         for scope in reversed(self.scope_stack):
             if name in scope["globals"]:
                 continue
             if name in scope["bindings"]:
-                return name in scope["args"]
+                if name not in scope["args"]:
+                    return False
+                if not self.rename_arguments:
+                    return True
+                return name not in scope.get("renamed_args", set())
         return False
 
     def _local_scope_state(self, node):
@@ -711,6 +740,31 @@ class VariableShortener(NodeTransformer):
             "used_names": used_names,
             "generator": variable_name_generator(used_names),
         }
+
+    def _receiver_class_name(self, node):
+        if isinstance(node, ast.Name):
+            return self._lookup_instance_type(node.id)
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                if func.id in self.class_member_mappings or func.id in self.class_method_argument_infos:
+                    return func.id
+                class_context = self._current_class_context()
+                if class_context is not None and func.id in {
+                    class_context["old_name"],
+                    class_context["new_name"],
+                }:
+                    return func.id
+        return None
+
+    def _record_instance_assignment(self, target, value):
+        class_name = self._receiver_class_name(value)
+        if isinstance(target, ast.Name):
+            self._set_instance_type(target.id, class_name)
+            return
+        if isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._record_instance_assignment(element, value)
 
     def _visit_ImportOrImportFrom(self, node):
         """Shorten imported library names.
@@ -784,9 +838,11 @@ class VariableShortener(NodeTransformer):
             }
             self.class_context_stack.append(class_context)
             self.scope_stack.append(self._scope_bindings(node))
+            self._push_instance_scope()
             try:
                 node = self.generic_visit(node)
             finally:
+                self._pop_instance_scope()
                 self.scope_stack.pop()
                 self.class_context_stack.pop()
             if class_context["member_mapping"]:
@@ -817,9 +873,11 @@ class VariableShortener(NodeTransformer):
         }
         self.class_context_stack.append(class_context)
         self.scope_stack.append(self._scope_bindings(node))
+        self._push_instance_scope()
         try:
             node = self.generic_visit(node)
         finally:
+            self._pop_instance_scope()
             self.scope_stack.pop()
             self.class_context_stack.pop()
         if class_context["member_mapping"]:
@@ -851,13 +909,16 @@ class VariableShortener(NodeTransformer):
         if self._preserve_function_name(node.name):
             self.scope_stack.append(self._scope_bindings(node))
             self.local_rename_scopes.append(self._local_scope_state(node))
+            self._push_instance_scope()
             try:
                 argument_info = self._rename_function_arguments(node)
+                self.scope_stack[-1]["renamed_args"] = set(argument_info["rename_map"])
                 class_context = self._current_class_context()
                 if class_context is not None:
                     class_context["receiver_names"].update(argument_info["receiver_names"])
                 return self.generic_visit(node)
             finally:
+                self._pop_instance_scope()
                 self.local_rename_scopes.pop()
                 self.scope_stack.pop()
         if self._is_method_definition(node):
@@ -880,8 +941,10 @@ class VariableShortener(NodeTransformer):
                     )
             self.scope_stack.append(self._scope_bindings(node))
             self.local_rename_scopes.append(self._local_scope_state(node))
+            self._push_instance_scope()
             try:
                 argument_info = self._rename_function_arguments(node)
+                self.scope_stack[-1]["renamed_args"] = set(argument_info["rename_map"])
                 if class_context is not None:
                     class_context["receiver_names"].update(argument_info["receiver_names"])
                     if argument_info["rename_map"] or argument_info["positional_params"]:
@@ -893,6 +956,7 @@ class VariableShortener(NodeTransformer):
                         class_context["argument_infos"][node.name] = copied
                 return self.generic_visit(node)
             finally:
+                self._pop_instance_scope()
                 self.local_rename_scopes.pop()
                 self.scope_stack.pop()
         if self.keep_global_variables and self._is_node_global(node):
@@ -901,22 +965,28 @@ class VariableShortener(NodeTransformer):
                 self._append_public_alias(old_name, node.name)
             self.scope_stack.append(self._scope_bindings(node))
             self.local_rename_scopes.append(self._local_scope_state(node))
+            self._push_instance_scope()
             try:
                 argument_info = self._rename_function_arguments(node)
+                self.scope_stack[-1]["renamed_args"] = set(argument_info["rename_map"])
                 self._record_callable_argument_info(old_name, node.name, argument_info)
                 return self.generic_visit(node)
             finally:
+                self._pop_instance_scope()
                 self.local_rename_scopes.pop()
                 self.scope_stack.pop()
         if node.name not in self.mapping_values:
             node.name = self._rename_identifier(node.name)
         self.scope_stack.append(self._scope_bindings(node))
         self.local_rename_scopes.append(self._local_scope_state(node))
+        self._push_instance_scope()
         try:
             argument_info = self._rename_function_arguments(node)
+            self.scope_stack[-1]["renamed_args"] = set(argument_info["rename_map"])
             self._record_callable_argument_info(old_name, node.name, argument_info)
             return self.generic_visit(node)
         finally:
+            self._pop_instance_scope()
             self.local_rename_scopes.pop()
             self.scope_stack.pop()
 
@@ -989,10 +1059,18 @@ class VariableShortener(NodeTransformer):
                 else:
                     self.visit(target)
             node.value = self.visit(node.value)
+            for target in node.targets:
+                self._record_instance_assignment(target, node.value)
             return node
         for target in node.targets:
-            self._rename_assignment_target(target)
-        return self.generic_visit(node)
+            if self._binding_names_from_target(target):
+                self._rename_assignment_target(target)
+            else:
+                self.visit(target)
+        node.value = self.visit(node.value)
+        for target in node.targets:
+            self._record_instance_assignment(target, node.value)
+        return node
 
     def visit_For(self, node):
         if not self._should_preserve_binding_targets(node):
@@ -1039,17 +1117,24 @@ class VariableShortener(NodeTransformer):
     def visit_Attribute(self, node):
         node.value = self.visit(node.value)
         base_name = node.value.id if isinstance(node.value, ast.Name) else None
-        if base_name is None:
-            return node
         attribute_mapping = None
         class_context = self._current_class_context()
-        if class_context is not None and base_name in {
-            class_context["old_name"],
-            class_context["new_name"],
-        } | class_context["receiver_names"]:
-            attribute_mapping = class_context["member_mapping"]
-        elif base_name in self.class_member_mappings:
-            attribute_mapping = self.class_member_mappings[base_name]
+        if base_name is not None:
+            if class_context is not None and base_name in {
+                class_context["old_name"],
+                class_context["new_name"],
+            } | class_context["receiver_names"]:
+                attribute_mapping = class_context["member_mapping"]
+            else:
+                instance_class = self._lookup_instance_type(base_name)
+                if instance_class in self.class_member_mappings:
+                    attribute_mapping = self.class_member_mappings[instance_class]
+                elif base_name in self.class_member_mappings:
+                    attribute_mapping = self.class_member_mappings[base_name]
+        if attribute_mapping is None:
+            receiver_class = self._receiver_class_name(node.value)
+            if receiver_class in self.class_member_mappings:
+                attribute_mapping = self.class_member_mappings[receiver_class]
         if attribute_mapping and node.attr in attribute_mapping:
             node.attr = attribute_mapping[node.attr]
         return node
@@ -1668,7 +1753,11 @@ class ImportedVariableShortener(VariableShortener):
                 if alias.name in shortener.mapping:
                     self.mapping[alias.name] = alias.name = shortener.mapping[alias.name]
                     if imported_name != alias.name and imported_name in self.callable_argument_infos:
-                        self.callable_argument_infos[alias.name] = self.callable_argument_infos.pop(imported_name)
+                        copied = self.callable_argument_infos[imported_name]
+                        self.callable_argument_infos[alias.name] = {
+                            "rename_map": dict(copied["rename_map"]),
+                            "positional_params": list(copied["positional_params"]),
+                        }
             if node.level == 0 and module_name in self.module_to_module:
                 node.module = self.module_to_module[module_name]
         return self.generic_visit(node)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1138,6 +1138,46 @@ def test_minify_rewrites_internal_keyword_calls_when_renaming_arguments(tmp_path
     assert modules == ["main"]
 
 
+def test_minify_reuses_short_argument_names_per_function_scope(tmp_path):
+    cleaned, modules = minify(
+        py(
+            """
+            def left(alpha):
+                return alpha + 1
+
+            def right(beta):
+                return beta + 2
+
+            print(left(1), right(2))
+            """
+        ),
+        "main",
+        keep_global_variables=True,
+        keep_module_names=True,
+        rename_arguments=True,
+    )
+
+    tree = ast.parse(cleaned[0])
+    functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
+    arg_names = [function.args.args[0].arg for function in functions]
+
+    assert len(set(arg_names)) == 1
+    assert len(arg_names[0]) == 1
+
+    module_path = tmp_path / "module.py"
+    module_path.write_text(cleaned[0], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "2 4\n"
+    assert modules == ["main"]
+
+
 def test_minify_fuses_files_into_single_module(tmp_path):
     cleaned, modules = minify(
         [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1178,6 +1178,176 @@ def test_minify_reuses_short_argument_names_per_function_scope(tmp_path):
     assert modules == ["main"]
 
 
+def test_minify_keeps_recursive_functions_callable_when_reusing_local_names(tmp_path):
+    cleaned, modules = minify(
+        py(
+            """
+            def recur(value):
+                if value <= 0:
+                    return 0
+                return recur(value - 1)
+
+            print(recur(3))
+            """
+        ),
+        "main",
+        keep_global_variables=True,
+        keep_module_names=True,
+        rename_arguments=True,
+    )
+
+    module_path = tmp_path / "module.py"
+    module_path.write_text(cleaned[0], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "0\n"
+    assert modules == ["main"]
+
+
+def test_minify_keeps_unrenamed_parameter_assignments_stable(tmp_path):
+    cleaned, modules = minify(
+        py(
+            """
+            def choose(x, flag):
+                if flag:
+                    x = 2
+                return x
+
+            print(choose(1, False))
+            print(choose(1, True))
+            """
+        ),
+        "main",
+        rename_arguments=True,
+        keep_module_names=True,
+    )
+
+    module_path = tmp_path / "module.py"
+    module_path.write_text(cleaned[0], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1\n2\n"
+    assert modules == ["main"]
+
+
+def test_minify_rewrites_renamed_methods_on_local_instances(tmp_path):
+    cleaned, modules = minify(
+        py(
+            """
+            class Demo:
+                def test(self):
+                    return 1
+
+            instance = Demo()
+            print(instance.test())
+            """
+        ),
+        "main",
+        rename_arguments=True,
+        keep_module_names=True,
+    )
+
+    assert ".test(" not in cleaned[0]
+
+    module_path = tmp_path / "module.py"
+    module_path.write_text(cleaned[0], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1\n"
+    assert modules == ["main"]
+
+
+def test_minify_rewrites_constructor_method_keywords_when_renaming_arguments(tmp_path):
+    cleaned, modules = minify(
+        py(
+            """
+            class Demo:
+                def scale(self, long_value):
+                    return long_value
+
+            print(Demo().scale(long_value=1))
+            """
+        ),
+        "main",
+        rename_arguments=True,
+        keep_module_names=True,
+    )
+
+    assert "long_value=" not in cleaned[0]
+
+    module_path = tmp_path / "module.py"
+    module_path.write_text(cleaned[0], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1\n"
+    assert modules == ["main"]
+
+
+def test_minify_keeps_import_alias_argument_metadata(tmp_path):
+    cleaned, modules = minify(
+        [
+            py(
+                """
+                def square(long_value):
+                    return long_value * long_value
+                """
+            ),
+            py(
+                """
+                from main import square as g
+
+                print(g(long_value=3))
+                """
+            ),
+        ],
+        ["main", "side"],
+        keep_module_names=True,
+        rename_arguments=True,
+    )
+
+    assert "long_value=" not in cleaned[1]
+
+    main_path = tmp_path / "main.py"
+    side_path = tmp_path / "side.py"
+    main_path.write_text(cleaned[0], encoding="utf-8")
+    side_path.write_text(cleaned[1], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(side_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "9\n"
+    assert modules == ["main", "side"]
+
+
 def test_minify_fuses_files_into_single_module(tmp_path):
     cleaned, modules = minify(
         [


### PR DESCRIPTION
## Summary
- refresh local name allocation so function-local bindings can reuse short names per scope while keeping cross-file/package renames on the shared allocator
- address the actionable Codex review findings from the last compression PR around parameter assignments, local-instance method rewrites, constructor-call keyword rewrites, and import-alias callable metadata
- regenerate the checked-in example outputs and update the top-level and benchmark README numbers to the new aggressive compression results

## Why
The previous package-mode compression work still left a lot of gzip redundancy on the table because local names stayed unnecessarily unique across functions. Reusing short locals per scope improves both raw source size and compressed package size. Folding in the unresolved review fixes at the same time keeps the aggressive renaming path correct.

## Impact
- TexSoup raw Python source now goes from `98,181` bytes to `24,288` bytes (`75.3%` smaller)
- TexSoup `.tar.gz` now goes from `23,101` bytes to `8,355` bytes (`63.8%` smaller)
- the branch adds regression coverage for recursive functions, unrenamed parameter assignment stability, local-instance method rewrites, constructor-call keyword rewrites, and import-alias callable metadata

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest`
- `PYTHONPATH=. .venv/bin/python scripts/regenerate_examples.py --check`
- aggressive TexSoup package validation: upstream `78` tests passed