### PR TITLE
Add benchmark summary chart

### DIFF
--- a/benchmarks/competitor_summary.svg
+++ b/benchmarks/competitor_summary.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="430" viewBox="0 0 980 430" fill="none">
+<rect x="0" y="0" width="980" height="430" rx="0" fill="#ffffff" stroke="none" />
+<text x="36" y="32" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" text-anchor="start">pymini Benchmark Snapshot</text>
+<text x="36" y="54" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="400" text-anchor="start">Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026</text>
+<rect x="36" y="66" width="14" height="14" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="58" y="78" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pymini</text>
+<rect x="184" y="66" width="14" height="14" rx="4" fill="#6e7c91" stroke="none" />
+<text x="206" y="78" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pyminifier</text>
+<rect x="332" y="66" width="14" height="14" rx="4" fill="#c06b3e" stroke="none" />
+<text x="354" y="78" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">python-minifier</text>
+<rect x="36.0" y="102" width="440.0" height="270" rx="14" fill="#fafbfc" stroke="#e4e7ec" />
+<text x="54.0" y="130" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Compression</text>
+<text x="54.0" y="150" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Minify-only compression multiplier by package; higher is better</text>
+<line x1="90.0" y1="320.0" x2="460.0" y2="320.0" stroke="#eceef2" />
+<text x="80.0" y="324.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">0x</text>
+<line x1="90.0" y1="286.0" x2="460.0" y2="286.0" stroke="#eceef2" />
+<text x="80.0" y="290.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1x</text>
+<line x1="90.0" y1="252.0" x2="460.0" y2="252.0" stroke="#eceef2" />
+<text x="80.0" y="256.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">2x</text>
+<line x1="90.0" y1="218.0" x2="460.0" y2="218.0" stroke="#eceef2" />
+<text x="80.0" y="222.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3x</text>
+<line x1="90.0" y1="184.0" x2="460.0" y2="184.0" stroke="#eceef2" />
+<text x="80.0" y="188.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">4x</text>
+<line x1="90.0" y1="184" x2="90.0" y2="320" stroke="#d5d8df" />
+<line x1="90.0" y1="320" x2="460.0" y2="320" stroke="#d5d8df" />
+<rect x="109.66666666666666" y="184.0" width="24" height="136.0" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="121.66666666666666" y="174.0" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">4.0x</text>
+<rect x="139.66666666666666" y="224.8" width="24" height="95.19999999999999" rx="4" fill="#6e7c91" stroke="none" />
+<text x="151.66666666666666" y="214.8" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.8x</text>
+<rect x="169.66666666666666" y="279.2" width="24" height="40.8" rx="4" fill="#c06b3e" stroke="none" />
+<text x="181.66666666666666" y="269.2" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
+<text x="151.66666666666666" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
+<rect x="232.99999999999997" y="255.4" width="24" height="64.6" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="244.99999999999997" y="245.4" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.9x</text>
+<rect x="263.0" y="279.2" width="24" height="40.8" rx="4" fill="#6e7c91" stroke="none" />
+<text x="275.0" y="269.2" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
+<rect x="293.0" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" />
+<text x="305.0" y="255.60000000000002" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
+<text x="275.0" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
+<rect x="356.3333333333333" y="231.6" width="24" height="88.4" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="368.3333333333333" y="221.6" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.6x</text>
+<rect x="386.3333333333333" y="296" width="24" height="24" rx="5" fill="#ffffff" stroke="#c7cdd8" stroke-dasharray="4 4" />
+<text x="398.3333333333333" y="286" fill="#b42318" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
+<rect x="416.3333333333333" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" />
+<text x="428.3333333333333" y="255.60000000000002" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
+<text x="398.3333333333333" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
+<rect x="504.0" y="102" width="440.0" height="270" rx="14" fill="#fafbfc" stroke="#e4e7ec" />
+<text x="522.0" y="130" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Speed</text>
+<text x="522.0" y="150" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Mean package minification time; lower is better (log scale)</text>
+<line x1="558.0" y1="313.4101191154522" x2="928.0" y2="313.4101191154522" stroke="#eceef2" />
+<text x="548.0" y="317.4101191154522" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">50 ms</text>
+<line x1="558.0" y1="292.94007941030145" x2="928.0" y2="292.94007941030145" stroke="#eceef2" />
+<text x="548.0" y="296.94007941030145" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">100 ms</text>
+<line x1="558.0" y1="245.41011911545218" x2="928.0" y2="245.41011911545218" stroke="#eceef2" />
+<text x="548.0" y="249.41011911545218" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">500 ms</text>
+<line x1="558.0" y1="224.94007941030145" x2="928.0" y2="224.94007941030145" stroke="#eceef2" />
+<text x="548.0" y="228.94007941030145" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1000 ms</text>
+<line x1="558.0" y1="192.4958340893644" x2="928.0" y2="192.4958340893644" stroke="#eceef2" />
+<text x="548.0" y="196.4958340893644" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3000 ms</text>
+<line x1="558.0" y1="184" x2="558.0" y2="320" stroke="#d5d8df" />
+<line x1="558.0" y1="320" x2="928.0" y2="320" stroke="#d5d8df" />
+<rect x="577.6666666666666" y="286.3738336008602" width="24" height="33.62616639913979" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="589.6666666666666" y="276.3738336008602" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">124.9 ms</text>
+<rect x="607.6666666666666" y="312.1384852061476" width="24" height="7.861514793852387" rx="4" fill="#6e7c91" stroke="none" />
+<text x="619.6666666666666" y="302.1384852061476" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">52.2 ms</text>
+<rect x="637.6666666666666" y="288.2530018159205" width="24" height="31.746998184079466" rx="4" fill="#c06b3e" stroke="none" />
+<text x="649.6666666666666" y="278.2530018159205" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">117.2 ms</text>
+<text x="619.6666666666666" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
+<rect x="701.0" y="255.7751782937885" width="24" height="64.22482170621149" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="713.0" y="245.7751782937885" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">352.0 ms</text>
+<rect x="731.0" y="303.05451169740434" width="24" height="16.94548830259568" rx="4" fill="#6e7c91" stroke="none" />
+<text x="743.0" y="293.05451169740434" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">71.0 ms</text>
+<rect x="761.0" y="264.0481281193889" width="24" height="55.95187188061112" rx="4" fill="#c06b3e" stroke="none" />
+<text x="773.0" y="254.04812811938888" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">266.0 ms</text>
+<text x="743.0" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
+<rect x="824.3333333333333" y="189.8012935481831" width="24" height="130.1987064518169" rx="4" fill="#1f7a5a" stroke="none" />
+<text x="836.3333333333333" y="179.8012935481831" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3286.6 ms</text>
+<rect x="854.3333333333333" y="296" width="24" height="24" rx="5" fill="#ffffff" stroke="#c7cdd8" stroke-dasharray="4 4" />
+<text x="866.3333333333333" y="286" fill="#b42318" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
+<rect x="884.3333333333333" y="206.9533398374209" width="24" height="113.04666016257909" rx="4" fill="#c06b3e" stroke="none" />
+<text x="896.3333333333333" y="196.9533398374209" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1838.7 ms</text>
+<text x="866.3333333333333" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
+</svg>

--- a/benchmarks/plot_summary_svg.py
+++ b/benchmarks/plot_summary_svg.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Generate a benchmark summary chart in the same house style as TexSoup."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+OUT = Path(__file__).with_name("competitor_summary.svg")
+
+TOOLS = (
+    {"name": "pymini", "color": "#1f7a5a"},
+    {"name": "pyminifier", "color": "#6e7c91"},
+    {"name": "python-minifier", "color": "#c06b3e"},
+)
+
+PACKAGES = (
+    {
+        "name": "TexSoup",
+        "speed_ms": {"pymini": 124.9, "pyminifier": 52.2, "python-minifier": 117.2},
+        "compression_x": {"pymini": 4.0, "pyminifier": 2.8, "python-minifier": 1.2},
+    },
+    {
+        "name": "timefhuman",
+        "speed_ms": {"pymini": 352.0, "pyminifier": 71.0, "python-minifier": 266.0},
+        "compression_x": {"pymini": 1.9, "pyminifier": 1.2, "python-minifier": 1.6},
+    },
+    {
+        "name": "rich",
+        "speed_ms": {"pymini": 3286.6, "pyminifier": None, "python-minifier": 1838.7},
+        "compression_x": {"pymini": 2.6, "pyminifier": None, "python-minifier": 1.6},
+    },
+)
+
+WIDTH = 980
+HEIGHT = 430
+PADDING = 36
+TITLE_Y = 32
+SUBTITLE_Y = 54
+LEGEND_Y = 77
+PANEL_GAP = 28
+PANEL_TOP = 102
+PANEL_HEIGHT = 270
+PANEL_WIDTH = (WIDTH - PADDING * 2 - PANEL_GAP) / 2
+BAR_GAP = 6
+BAR_WIDTH = 24
+AXIS_COLOR = "#d5d8df"
+GRID_COLOR = "#eceef2"
+TEXT_COLOR = "#1c1f24"
+MUTED = "#5d6674"
+FONT = "ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+
+
+def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR):
+    return (
+        f'<text x="{x}" y="{y}" fill="{fill}" font-family="{FONT}" '
+        f'font-size="{size}" font-weight="{weight}" text-anchor="{anchor}">'
+        f"{escape(text)}</text>"
+    )
+
+
+def svg_rect(x, y, width, height, fill, rx=8, stroke="none", dash=None, opacity=None):
+    dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
+    opacity_attr = f' opacity="{opacity}"' if opacity is not None else ""
+    return (
+        f'<rect x="{x}" y="{y}" width="{width}" height="{height}" rx="{rx}" '
+        f'fill="{fill}" stroke="{stroke}"{dash_attr}{opacity_attr} />'
+    )
+
+
+def panel_origin(index):
+    return PADDING + index * (PANEL_WIDTH + PANEL_GAP), PANEL_TOP
+
+
+def draw_panel_frame(elements, x, y, width, height, title, subtitle):
+    elements.append(svg_rect(x, y, width, height, "#fafbfc", rx=14, stroke="#e4e7ec"))
+    elements.append(svg_text(x + 18, y + 28, title, size=16, weight="600"))
+    elements.append(svg_text(x + 18, y + 48, subtitle, size=12, fill=MUTED))
+
+
+def draw_legend(elements):
+    x = PADDING
+    for tool in TOOLS:
+        elements.append(svg_rect(x, LEGEND_Y - 11, 14, 14, tool["color"], rx=4))
+        elements.append(svg_text(x + 22, LEGEND_Y + 1, tool["name"], size=12, fill=MUTED))
+        x += 148
+
+
+def layout_groups(axis_left, axis_right, group_count):
+    group_width = (axis_right - axis_left) / group_count
+    cluster_width = len(TOOLS) * BAR_WIDTH + (len(TOOLS) - 1) * BAR_GAP
+    return group_width, cluster_width
+
+
+def group_center(axis_left, group_width, group_index):
+    return axis_left + group_width * (group_index + 0.5)
+
+
+def group_start_x(axis_left, group_width, group_index, cluster_width):
+    return axis_left + group_width * group_index + (group_width - cluster_width) / 2
+
+
+def draw_compression_panel(elements, x, y, width, height, title, subtitle, packages, max_value=4.0):
+    draw_panel_frame(elements, x, y, width, height, title, subtitle)
+    axis_left = x + 54
+    axis_right = x + width - 16
+    axis_top = y + 82
+    axis_bottom = y + height - 52
+    axis_height = axis_bottom - axis_top
+
+    for tick in (0, 1, 2, 3, 4):
+        tick_y = axis_bottom - axis_height * (tick / max_value)
+        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID_COLOR}" />')
+        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick}x", size=11, anchor="end", fill=MUTED))
+
+    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
+    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
+
+    group_width, cluster_width = layout_groups(axis_left, axis_right, len(packages))
+
+    for group_index, package in enumerate(packages):
+        center = group_center(axis_left, group_width, group_index)
+        start_x = group_start_x(axis_left, group_width, group_index, cluster_width)
+        for tool_index, tool in enumerate(TOOLS):
+            value = package["compression_x"][tool["name"]]
+            bar_x = start_x + tool_index * (BAR_WIDTH + BAR_GAP)
+            if value is None:
+                fail_height = 24
+                fail_y = axis_bottom - fail_height
+                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, "#ffffff", rx=5, stroke="#c7cdd8", dash="4 4"))
+                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill="#b42318"))
+                continue
+            bar_height = axis_height * (value / max_value)
+            bar_y = axis_bottom - bar_height
+            elements.append(svg_rect(bar_x, bar_y, BAR_WIDTH, bar_height, tool["color"], rx=4))
+            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f}x", size=10, weight="600", anchor="middle"))
+        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor="middle", fill=MUTED))
+
+
+def draw_speed_panel(elements):
+    x, y = panel_origin(1)
+    draw_panel_frame(elements, x, y, PANEL_WIDTH, PANEL_HEIGHT, "Speed", "Mean package minification time; lower is better (log scale)")
+    axis_left = x + 54
+    axis_right = x + PANEL_WIDTH - 16
+    axis_top = y + 82
+    axis_bottom = y + PANEL_HEIGHT - 52
+    axis_height = axis_bottom - axis_top
+    log_min = math.log10(40)
+    log_max = math.log10(4000)
+    ticks = (50, 100, 500, 1000, 3000)
+
+    for tick in ticks:
+        fraction = (math.log10(tick) - log_min) / (log_max - log_min)
+        tick_y = axis_bottom - axis_height * fraction
+        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID_COLOR}" />')
+        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick:g} ms", size=11, anchor="end", fill=MUTED))
+
+    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
+    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
+
+    group_width, cluster_width = layout_groups(axis_left, axis_right, len(PACKAGES))
+
+    for group_index, package in enumerate(PACKAGES):
+        center = group_center(axis_left, group_width, group_index)
+        start_x = group_start_x(axis_left, group_width, group_index, cluster_width)
+        for tool_index, tool in enumerate(TOOLS):
+            value = package["speed_ms"][tool["name"]]
+            bar_x = start_x + tool_index * (BAR_WIDTH + BAR_GAP)
+            if value is None:
+                fail_height = 24
+                fail_y = axis_bottom - fail_height
+                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, "#ffffff", rx=5, stroke="#c7cdd8", dash="4 4"))
+                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill="#b42318"))
+                continue
+            fraction = (math.log10(value) - log_min) / (log_max - log_min)
+            bar_height = max(axis_height * fraction, 4)
+            bar_y = axis_bottom - bar_height
+            elements.append(svg_rect(bar_x, bar_y, BAR_WIDTH, bar_height, tool["color"], rx=4))
+            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f} ms", size=10, weight="600", anchor="middle"))
+        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor="middle", fill=MUTED))
+
+
+def build_svg():
+    elements = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" fill="none">',
+        svg_rect(0, 0, WIDTH, HEIGHT, "#ffffff", rx=0),
+        svg_text(PADDING, TITLE_Y, "pymini Benchmark Snapshot", size=24, weight="700"),
+        svg_text(
+            PADDING,
+            SUBTITLE_Y,
+            "Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026",
+            size=13,
+            fill=MUTED,
+        ),
+    ]
+    draw_legend(elements)
+    draw_compression_panel(
+        elements,
+        *panel_origin(0),
+        PANEL_WIDTH,
+        PANEL_HEIGHT,
+        "Compression",
+        "Minify-only compression multiplier by package; higher is better",
+        PACKAGES,
+    )
+    draw_speed_panel(elements)
+    elements.append("</svg>")
+    return "\n".join(elements)
+
+def main():
+    OUT.write_text(build_svg() + "\n", encoding="utf-8")
+    print(OUT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an SVG benchmark summary chart in the existing TexSoup/timefhuman house style
- keep the chart focused on the two-panel compression and speed snapshot
- include the chart generator script alongside the generated SVG so the asset can be regenerated

## Validation
- `python3 benchmarks/plot_summary_svg.py`
