### PR TITLE
Match benchmark chart to TexSoup styling

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,6 +9,8 @@ the benchmark harness used to reproduce them.
 
 # Results
 
+![Benchmark summary chart comparing minify-only compression and speed across packages](./competitor_summary.svg)
+
 ## Compression
 
 Compression multipliers below are all relative to the original raw Python

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,7 +9,7 @@ the benchmark harness used to reproduce them.
 
 # Results
 
-![Benchmark summary chart comparing minify-only compression and speed across packages](./competitor_summary.svg)
+![Benchmark summary chart comparing minify-only compression and speed across packages](./summary.svg)
 
 ## Compression
 

--- a/benchmarks/competitor_summary.svg
+++ b/benchmarks/competitor_summary.svg
@@ -2,105 +2,112 @@
 <style>
   svg {
     color-scheme: light dark;
-  }
-
-  .chart-background {
-    fill: #0f172a;
-    fill-opacity: 0.1;
+    --bg: rgba(15, 23, 42, 0.10);
+    --panel: rgba(250, 251, 252, 0.92);
+    --panel-stroke: #e4e7ec;
+    --grid: #eceef2;
+    --axis: #d5d8df;
+    --text: #1c1f24;
+    --muted: #5d6674;
+    --fail-fill: rgba(255, 255, 255, 0.9);
+    --fail-stroke: #c7cdd8;
+    --fail-text: #b42318;
   }
 
   @media (prefers-color-scheme: dark) {
-    .chart-body {
-      filter: invert(1) hue-rotate(180deg);
-    }
-
-    .chart-background {
-      fill: #f8fafc;
-      fill-opacity: 0.08;
+    svg {
+      --bg: rgba(248, 250, 252, 0.08);
+      --panel: rgba(21, 26, 35, 0.88);
+      --panel-stroke: #2f3847;
+      --grid: #2a3140;
+      --axis: #3a4456;
+      --text: #f3f5f8;
+      --muted: #b7bfcb;
+      --fail-fill: rgba(255, 255, 255, 0.06);
+      --fail-stroke: #8f9bad;
+      --fail-text: #f6c3be;
     }
   }
 </style>
-<rect x="0" y="0" width="980" height="430" rx="22" fill="#0f172a" stroke="none" class="chart-background" />
-<g class="chart-body">
-<text x="36" y="32" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" text-anchor="start">pymini Benchmark Snapshot</text>
-<text x="36" y="54" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="400" text-anchor="start">Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026</text>
+<rect x="0" y="0" width="980" height="430" rx="22" fill="var(--bg)" stroke="none" />
+<text x="36" y="32" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" text-anchor="start">pymini Benchmark Snapshot</text>
+<text x="36" y="54" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="400" text-anchor="start">Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026</text>
 <rect x="36" y="66" width="14" height="14" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="58" y="78" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pymini</text>
+<text x="58" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pymini</text>
 <rect x="184" y="66" width="14" height="14" rx="4" fill="#6e7c91" stroke="none" />
-<text x="206" y="78" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pyminifier</text>
+<text x="206" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pyminifier</text>
 <rect x="332" y="66" width="14" height="14" rx="4" fill="#c06b3e" stroke="none" />
-<text x="354" y="78" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">python-minifier</text>
-<rect x="36.0" y="102" width="440.0" height="270" rx="14" fill="#fafbfc" stroke="#e4e7ec" />
-<text x="54.0" y="130" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Compression</text>
-<text x="54.0" y="150" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Minify-only compression multiplier by package; higher is better</text>
-<line x1="90.0" y1="320.0" x2="460.0" y2="320.0" stroke="#eceef2" />
-<text x="80.0" y="324.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">0x</text>
-<line x1="90.0" y1="286.0" x2="460.0" y2="286.0" stroke="#eceef2" />
-<text x="80.0" y="290.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1x</text>
-<line x1="90.0" y1="252.0" x2="460.0" y2="252.0" stroke="#eceef2" />
-<text x="80.0" y="256.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">2x</text>
-<line x1="90.0" y1="218.0" x2="460.0" y2="218.0" stroke="#eceef2" />
-<text x="80.0" y="222.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3x</text>
-<line x1="90.0" y1="184.0" x2="460.0" y2="184.0" stroke="#eceef2" />
-<text x="80.0" y="188.0" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">4x</text>
-<line x1="90.0" y1="184" x2="90.0" y2="320" stroke="#d5d8df" />
-<line x1="90.0" y1="320" x2="460.0" y2="320" stroke="#d5d8df" />
+<text x="354" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">python-minifier</text>
+<rect x="36.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" />
+<text x="54.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Compression</text>
+<text x="54.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Minify-only compression multiplier by package; higher is better</text>
+<line x1="90.0" y1="320.0" x2="460.0" y2="320.0" stroke="var(--grid)" />
+<text x="80.0" y="324.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">0x</text>
+<line x1="90.0" y1="286.0" x2="460.0" y2="286.0" stroke="var(--grid)" />
+<text x="80.0" y="290.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1x</text>
+<line x1="90.0" y1="252.0" x2="460.0" y2="252.0" stroke="var(--grid)" />
+<text x="80.0" y="256.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">2x</text>
+<line x1="90.0" y1="218.0" x2="460.0" y2="218.0" stroke="var(--grid)" />
+<text x="80.0" y="222.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3x</text>
+<line x1="90.0" y1="184.0" x2="460.0" y2="184.0" stroke="var(--grid)" />
+<text x="80.0" y="188.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">4x</text>
+<line x1="90.0" y1="184" x2="90.0" y2="320" stroke="var(--axis)" />
+<line x1="90.0" y1="320" x2="460.0" y2="320" stroke="var(--axis)" />
 <rect x="109.66666666666666" y="184.0" width="24" height="136.0" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="121.66666666666666" y="174.0" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">4.0x</text>
+<text x="121.66666666666666" y="174.0" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">4.0x</text>
 <rect x="139.66666666666666" y="224.8" width="24" height="95.19999999999999" rx="4" fill="#6e7c91" stroke="none" />
-<text x="151.66666666666666" y="214.8" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.8x</text>
+<text x="151.66666666666666" y="214.8" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.8x</text>
 <rect x="169.66666666666666" y="279.2" width="24" height="40.8" rx="4" fill="#c06b3e" stroke="none" />
-<text x="181.66666666666666" y="269.2" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
-<text x="151.66666666666666" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
+<text x="181.66666666666666" y="269.2" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
+<text x="151.66666666666666" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
 <rect x="232.99999999999997" y="255.4" width="24" height="64.6" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="244.99999999999997" y="245.4" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.9x</text>
+<text x="244.99999999999997" y="245.4" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.9x</text>
 <rect x="263.0" y="279.2" width="24" height="40.8" rx="4" fill="#6e7c91" stroke="none" />
-<text x="275.0" y="269.2" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
+<text x="275.0" y="269.2" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
 <rect x="293.0" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" />
-<text x="305.0" y="255.60000000000002" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
-<text x="275.0" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
+<text x="305.0" y="255.60000000000002" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
+<text x="275.0" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
 <rect x="356.3333333333333" y="231.6" width="24" height="88.4" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="368.3333333333333" y="221.6" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.6x</text>
-<rect x="386.3333333333333" y="296" width="24" height="24" rx="5" fill="#ffffff" stroke="#c7cdd8" stroke-dasharray="4 4" />
-<text x="398.3333333333333" y="286" fill="#b42318" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
+<text x="368.3333333333333" y="221.6" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.6x</text>
+<rect x="386.3333333333333" y="296" width="24" height="24" rx="5" fill="var(--fail-fill)" stroke="var(--fail-stroke)" stroke-dasharray="4 4" />
+<text x="398.3333333333333" y="286" fill="var(--fail-text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
 <rect x="416.3333333333333" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" />
-<text x="428.3333333333333" y="255.60000000000002" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
-<text x="398.3333333333333" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
-<rect x="504.0" y="102" width="440.0" height="270" rx="14" fill="#fafbfc" stroke="#e4e7ec" />
-<text x="522.0" y="130" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Speed</text>
-<text x="522.0" y="150" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Mean package minification time; lower is better (log scale)</text>
-<line x1="558.0" y1="313.4101191154522" x2="928.0" y2="313.4101191154522" stroke="#eceef2" />
-<text x="548.0" y="317.4101191154522" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">50 ms</text>
-<line x1="558.0" y1="292.94007941030145" x2="928.0" y2="292.94007941030145" stroke="#eceef2" />
-<text x="548.0" y="296.94007941030145" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">100 ms</text>
-<line x1="558.0" y1="245.41011911545218" x2="928.0" y2="245.41011911545218" stroke="#eceef2" />
-<text x="548.0" y="249.41011911545218" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">500 ms</text>
-<line x1="558.0" y1="224.94007941030145" x2="928.0" y2="224.94007941030145" stroke="#eceef2" />
-<text x="548.0" y="228.94007941030145" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1000 ms</text>
-<line x1="558.0" y1="192.4958340893644" x2="928.0" y2="192.4958340893644" stroke="#eceef2" />
-<text x="548.0" y="196.4958340893644" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3000 ms</text>
-<line x1="558.0" y1="184" x2="558.0" y2="320" stroke="#d5d8df" />
-<line x1="558.0" y1="320" x2="928.0" y2="320" stroke="#d5d8df" />
+<text x="428.3333333333333" y="255.60000000000002" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
+<text x="398.3333333333333" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
+<rect x="504.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" />
+<text x="522.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Speed</text>
+<text x="522.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Mean package minification time; lower is better (log scale)</text>
+<line x1="558.0" y1="313.4101191154522" x2="928.0" y2="313.4101191154522" stroke="var(--grid)" />
+<text x="548.0" y="317.4101191154522" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">50 ms</text>
+<line x1="558.0" y1="292.94007941030145" x2="928.0" y2="292.94007941030145" stroke="var(--grid)" />
+<text x="548.0" y="296.94007941030145" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">100 ms</text>
+<line x1="558.0" y1="245.41011911545218" x2="928.0" y2="245.41011911545218" stroke="var(--grid)" />
+<text x="548.0" y="249.41011911545218" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">500 ms</text>
+<line x1="558.0" y1="224.94007941030145" x2="928.0" y2="224.94007941030145" stroke="var(--grid)" />
+<text x="548.0" y="228.94007941030145" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1000 ms</text>
+<line x1="558.0" y1="192.4958340893644" x2="928.0" y2="192.4958340893644" stroke="var(--grid)" />
+<text x="548.0" y="196.4958340893644" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3000 ms</text>
+<line x1="558.0" y1="184" x2="558.0" y2="320" stroke="var(--axis)" />
+<line x1="558.0" y1="320" x2="928.0" y2="320" stroke="var(--axis)" />
 <rect x="577.6666666666666" y="286.3738336008602" width="24" height="33.62616639913979" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="589.6666666666666" y="276.3738336008602" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">124.9 ms</text>
+<text x="589.6666666666666" y="276.3738336008602" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">124.9 ms</text>
 <rect x="607.6666666666666" y="312.1384852061476" width="24" height="7.861514793852387" rx="4" fill="#6e7c91" stroke="none" />
-<text x="619.6666666666666" y="302.1384852061476" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">52.2 ms</text>
+<text x="619.6666666666666" y="302.1384852061476" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">52.2 ms</text>
 <rect x="637.6666666666666" y="288.2530018159205" width="24" height="31.746998184079466" rx="4" fill="#c06b3e" stroke="none" />
-<text x="649.6666666666666" y="278.2530018159205" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">117.2 ms</text>
-<text x="619.6666666666666" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
+<text x="649.6666666666666" y="278.2530018159205" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">117.2 ms</text>
+<text x="619.6666666666666" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
 <rect x="701.0" y="255.7751782937885" width="24" height="64.22482170621149" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="713.0" y="245.7751782937885" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">352.0 ms</text>
+<text x="713.0" y="245.7751782937885" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">352.0 ms</text>
 <rect x="731.0" y="303.05451169740434" width="24" height="16.94548830259568" rx="4" fill="#6e7c91" stroke="none" />
-<text x="743.0" y="293.05451169740434" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">71.0 ms</text>
+<text x="743.0" y="293.05451169740434" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">71.0 ms</text>
 <rect x="761.0" y="264.0481281193889" width="24" height="55.95187188061112" rx="4" fill="#c06b3e" stroke="none" />
-<text x="773.0" y="254.04812811938888" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">266.0 ms</text>
-<text x="743.0" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
+<text x="773.0" y="254.04812811938888" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">266.0 ms</text>
+<text x="743.0" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
 <rect x="824.3333333333333" y="189.8012935481831" width="24" height="130.1987064518169" rx="4" fill="#1f7a5a" stroke="none" />
-<text x="836.3333333333333" y="179.8012935481831" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3286.6 ms</text>
-<rect x="854.3333333333333" y="296" width="24" height="24" rx="5" fill="#ffffff" stroke="#c7cdd8" stroke-dasharray="4 4" />
-<text x="866.3333333333333" y="286" fill="#b42318" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
+<text x="836.3333333333333" y="179.8012935481831" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3286.6 ms</text>
+<rect x="854.3333333333333" y="296" width="24" height="24" rx="5" fill="var(--fail-fill)" stroke="var(--fail-stroke)" stroke-dasharray="4 4" />
+<text x="866.3333333333333" y="286" fill="var(--fail-text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
 <rect x="884.3333333333333" y="206.9533398374209" width="24" height="113.04666016257909" rx="4" fill="#c06b3e" stroke="none" />
-<text x="896.3333333333333" y="196.9533398374209" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1838.7 ms</text>
-<text x="866.3333333333333" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
-</g>
+<text x="896.3333333333333" y="196.9533398374209" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1838.7 ms</text>
+<text x="866.3333333333333" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
 </svg>

--- a/benchmarks/competitor_summary.svg
+++ b/benchmarks/competitor_summary.svg
@@ -1,5 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="980" height="430" viewBox="0 0 980 430" fill="none">
-<rect x="0" y="0" width="980" height="430" rx="0" fill="#ffffff" stroke="none" />
+<style>
+  svg {
+    color-scheme: light dark;
+  }
+
+  .chart-background {
+    fill: #0f172a;
+    fill-opacity: 0.1;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .chart-body {
+      filter: invert(1) hue-rotate(180deg);
+    }
+
+    .chart-background {
+      fill: #f8fafc;
+      fill-opacity: 0.08;
+    }
+  }
+</style>
+<rect x="0" y="0" width="980" height="430" rx="22" fill="#0f172a" stroke="none" class="chart-background" />
+<g class="chart-body">
 <text x="36" y="32" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" text-anchor="start">pymini Benchmark Snapshot</text>
 <text x="36" y="54" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="400" text-anchor="start">Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026</text>
 <rect x="36" y="66" width="14" height="14" rx="4" fill="#1f7a5a" stroke="none" />
@@ -80,4 +102,5 @@
 <rect x="884.3333333333333" y="206.9533398374209" width="24" height="113.04666016257909" rx="4" fill="#c06b3e" stroke="none" />
 <text x="896.3333333333333" y="196.9533398374209" fill="#1c1f24" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1838.7 ms</text>
 <text x="866.3333333333333" y="340" fill="#5d6674" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
+</g>
 </svg>

--- a/benchmarks/plot.py
+++ b/benchmarks/plot.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
-"""Generate a benchmark summary chart in the same house style as TexSoup."""
+"""Generate a benchmark summary chart for the benchmarks README.
+
+This emits a plain SVG so the chart can be regenerated without adding plotting
+dependencies to the repository.
+
+Usage:
+    python3 benchmarks/plot.py
+    python3 benchmarks/plot.py --output benchmarks/summary.svg
+"""
 
 from __future__ import annotations
 
+import argparse
 import math
 from pathlib import Path
 from xml.sax.saxutils import escape
-
-OUT = Path(__file__).with_name("competitor_summary.svg")
 
 TOOLS = (
     {"name": "pymini", "color": "#1f7a5a"},
@@ -45,17 +52,25 @@ PANEL_HEIGHT = 270
 PANEL_WIDTH = (WIDTH - PADDING * 2 - PANEL_GAP) / 2
 BAR_GAP = 6
 BAR_WIDTH = 24
-BG_COLOR = "var(--bg)"
-PANEL_COLOR = "var(--panel)"
-PANEL_STROKE = "var(--panel-stroke)"
-AXIS_COLOR = "var(--axis)"
-GRID_COLOR = "var(--grid)"
-TEXT_COLOR = "var(--text)"
-MUTED = "var(--muted)"
-FAIL_FILL = "var(--fail-fill)"
-FAIL_STROKE = "var(--fail-stroke)"
-FAIL_TEXT = "var(--fail-text)"
-FONT = "ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+BG = 'var(--bg)'
+PANEL = 'var(--panel)'
+PANEL_STROKE = 'var(--panel-stroke)'
+GRID = 'var(--grid)'
+AXIS = 'var(--axis)'
+TEXT = 'var(--text)'
+MUTED = 'var(--muted)'
+FONT = 'ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--output',
+        type=Path,
+        default=Path('benchmarks/summary.svg'),
+        help='Where to write the SVG chart.',
+    )
+    return parser.parse_args()
 
 
 def style_block():
@@ -63,36 +78,30 @@ def style_block():
 <style>
   svg {
     color-scheme: light dark;
-    --bg: rgba(15, 23, 42, 0.10);
-    --panel: rgba(250, 251, 252, 0.92);
+    --bg: #ffffff;
+    --panel: #fafbfc;
     --panel-stroke: #e4e7ec;
     --grid: #eceef2;
     --axis: #d5d8df;
     --text: #1c1f24;
     --muted: #5d6674;
-    --fail-fill: rgba(255, 255, 255, 0.9);
-    --fail-stroke: #c7cdd8;
-    --fail-text: #b42318;
   }
 
   @media (prefers-color-scheme: dark) {
     svg {
-      --bg: rgba(248, 250, 252, 0.08);
-      --panel: rgba(21, 26, 35, 0.88);
+      --bg: #0e1117;
+      --panel: #151a23;
       --panel-stroke: #2f3847;
       --grid: #2a3140;
       --axis: #3a4456;
       --text: #f3f5f8;
       --muted: #b7bfcb;
-      --fail-fill: rgba(255, 255, 255, 0.06);
-      --fail-stroke: #8f9bad;
-      --fail-text: #f6c3be;
     }
   }
 </style>""".strip()
 
 
-def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR):
+def svg_text(x, y, text, size=14, weight='400', anchor='start', fill=TEXT):
     return (
         f'<text x="{x}" y="{y}" fill="{fill}" font-family="{FONT}" '
         f'font-size="{size}" font-weight="{weight}" text-anchor="{anchor}">'
@@ -100,12 +109,11 @@ def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR)
     )
 
 
-def svg_rect(x, y, width, height, fill, rx=8, stroke="none", dash=None, opacity=None):
-    dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
-    opacity_attr = f' opacity="{opacity}"' if opacity is not None else ""
+def svg_rect(x, y, width, height, fill, rx=8, stroke='none', stroke_width=1, dash=None):
+    dash_attr = f' stroke-dasharray="{dash}"' if dash else ''
     return (
         f'<rect x="{x}" y="{y}" width="{width}" height="{height}" rx="{rx}" '
-        f'fill="{fill}" stroke="{stroke}"{dash_attr}{opacity_attr} />'
+        f'fill="{fill}" stroke="{stroke}" stroke-width="{stroke_width}"{dash_attr} />'
     )
 
 
@@ -114,8 +122,8 @@ def panel_origin(index):
 
 
 def draw_panel_frame(elements, x, y, width, height, title, subtitle):
-    elements.append(svg_rect(x, y, width, height, PANEL_COLOR, rx=14, stroke=PANEL_STROKE))
-    elements.append(svg_text(x + 18, y + 28, title, size=16, weight="600"))
+    elements.append(svg_rect(x, y, width, height, PANEL, rx=14, stroke=PANEL_STROKE))
+    elements.append(svg_text(x + 18, y + 28, title, size=16, weight='600'))
     elements.append(svg_text(x + 18, y + 48, subtitle, size=12, fill=MUTED))
 
 
@@ -151,11 +159,11 @@ def draw_compression_panel(elements, x, y, width, height, title, subtitle, packa
 
     for tick in (0, 1, 2, 3, 4):
         tick_y = axis_bottom - axis_height * (tick / max_value)
-        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID_COLOR}" />')
-        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick}x", size=11, anchor="end", fill=MUTED))
+        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID}" />')
+        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick}x", size=11, anchor='end', fill=MUTED))
 
-    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
-    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
+    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS}" />')
+    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS}" />')
 
     group_width, cluster_width = layout_groups(axis_left, axis_right, len(packages))
 
@@ -168,19 +176,19 @@ def draw_compression_panel(elements, x, y, width, height, title, subtitle, packa
             if value is None:
                 fail_height = 24
                 fail_y = axis_bottom - fail_height
-                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, FAIL_FILL, rx=5, stroke=FAIL_STROKE, dash="4 4"))
-                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill=FAIL_TEXT))
+                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, 'none', rx=5, stroke=tool["color"], stroke_width=1.5, dash='6 4'))
+                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, 'fail', size=10, weight='600', anchor='middle', fill=MUTED))
                 continue
             bar_height = axis_height * (value / max_value)
             bar_y = axis_bottom - bar_height
             elements.append(svg_rect(bar_x, bar_y, BAR_WIDTH, bar_height, tool["color"], rx=4))
-            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f}x", size=10, weight="600", anchor="middle"))
-        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor="middle", fill=MUTED))
+            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f}x", size=10, weight='600', anchor='middle'))
+        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor='middle', fill=MUTED))
 
 
 def draw_speed_panel(elements):
     x, y = panel_origin(1)
-    draw_panel_frame(elements, x, y, PANEL_WIDTH, PANEL_HEIGHT, "Speed", "Mean package minification time; lower is better (log scale)")
+    draw_panel_frame(elements, x, y, PANEL_WIDTH, PANEL_HEIGHT, 'Speed', 'Mean package minification time; lower is better (log scale)')
     axis_left = x + 54
     axis_right = x + PANEL_WIDTH - 16
     axis_top = y + 82
@@ -193,11 +201,11 @@ def draw_speed_panel(elements):
     for tick in ticks:
         fraction = (math.log10(tick) - log_min) / (log_max - log_min)
         tick_y = axis_bottom - axis_height * fraction
-        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID_COLOR}" />')
-        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick:g} ms", size=11, anchor="end", fill=MUTED))
+        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID}" />')
+        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick:g} ms", size=11, anchor='end', fill=MUTED))
 
-    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
-    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS_COLOR}" />')
+    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS}" />')
+    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS}" />')
 
     group_width, cluster_width = layout_groups(axis_left, axis_right, len(PACKAGES))
 
@@ -210,27 +218,27 @@ def draw_speed_panel(elements):
             if value is None:
                 fail_height = 24
                 fail_y = axis_bottom - fail_height
-                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, FAIL_FILL, rx=5, stroke=FAIL_STROKE, dash="4 4"))
-                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill=FAIL_TEXT))
+                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, 'none', rx=5, stroke=tool["color"], stroke_width=1.5, dash='6 4'))
+                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, 'fail', size=10, weight='600', anchor='middle', fill=MUTED))
                 continue
             fraction = (math.log10(value) - log_min) / (log_max - log_min)
             bar_height = max(axis_height * fraction, 4)
             bar_y = axis_bottom - bar_height
             elements.append(svg_rect(bar_x, bar_y, BAR_WIDTH, bar_height, tool["color"], rx=4))
-            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f} ms", size=10, weight="600", anchor="middle"))
-        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor="middle", fill=MUTED))
+            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f} ms", size=10, weight='600', anchor='middle'))
+        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor='middle', fill=MUTED))
 
 
 def build_svg():
     elements = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" fill="none">',
         style_block(),
-        svg_rect(0, 0, WIDTH, HEIGHT, BG_COLOR, rx=22),
-        svg_text(PADDING, TITLE_Y, "pymini Benchmark Snapshot", size=24, weight="700"),
+        svg_rect(0, 0, WIDTH, HEIGHT, BG, rx=0),
+        svg_text(PADDING, TITLE_Y, 'pymini Benchmark Snapshot', size=24, weight='700'),
         svg_text(
             PADDING,
             SUBTITLE_Y,
-            "Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026",
+            'Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026',
             size=13,
             fill=MUTED,
         ),
@@ -241,17 +249,19 @@ def build_svg():
         *panel_origin(0),
         PANEL_WIDTH,
         PANEL_HEIGHT,
-        "Compression",
-        "Minify-only compression multiplier by package; higher is better",
+        'Compression',
+        'Minify-only compression multiplier by package; higher is better',
         PACKAGES,
     )
     draw_speed_panel(elements)
-    elements.append("</svg>")
+    elements.append('</svg>')
     return "\n".join(elements)
 
+
 def main():
-    OUT.write_text(build_svg() + "\n", encoding="utf-8")
-    print(OUT)
+    args = parse_args()
+    args.output.write_text(build_svg() + "\n", encoding="utf-8")
+    print(args.output)
 
 
 if __name__ == "__main__":

--- a/benchmarks/plot_summary_svg.py
+++ b/benchmarks/plot_summary_svg.py
@@ -50,6 +50,29 @@ GRID_COLOR = "#eceef2"
 TEXT_COLOR = "#1c1f24"
 MUTED = "#5d6674"
 FONT = "ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+STYLE = """\
+<style>
+  svg {
+    color-scheme: light dark;
+  }
+
+  .chart-background {
+    fill: #0f172a;
+    fill-opacity: 0.1;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .chart-body {
+      filter: invert(1) hue-rotate(180deg);
+    }
+
+    .chart-background {
+      fill: #f8fafc;
+      fill-opacity: 0.08;
+    }
+  }
+</style>
+"""
 
 
 def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR):
@@ -60,12 +83,13 @@ def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR)
     )
 
 
-def svg_rect(x, y, width, height, fill, rx=8, stroke="none", dash=None, opacity=None):
+def svg_rect(x, y, width, height, fill, rx=8, stroke="none", dash=None, opacity=None, class_name=None):
+    class_attr = f' class="{class_name}"' if class_name else ""
     dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
     opacity_attr = f' opacity="{opacity}"' if opacity is not None else ""
     return (
         f'<rect x="{x}" y="{y}" width="{width}" height="{height}" rx="{rx}" '
-        f'fill="{fill}" stroke="{stroke}"{dash_attr}{opacity_attr} />'
+        f'fill="{fill}" stroke="{stroke}"{class_attr}{dash_attr}{opacity_attr} />'
     )
 
 
@@ -184,7 +208,9 @@ def draw_speed_panel(elements):
 def build_svg():
     elements = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" fill="none">',
-        svg_rect(0, 0, WIDTH, HEIGHT, "#ffffff", rx=0),
+        STYLE.strip(),
+        svg_rect(0, 0, WIDTH, HEIGHT, "#0f172a", rx=22, class_name="chart-background"),
+        '<g class="chart-body">',
         svg_text(PADDING, TITLE_Y, "pymini Benchmark Snapshot", size=24, weight="700"),
         svg_text(
             PADDING,
@@ -205,6 +231,7 @@ def build_svg():
         PACKAGES,
     )
     draw_speed_panel(elements)
+    elements.append("</g>")
     elements.append("</svg>")
     return "\n".join(elements)
 

--- a/benchmarks/plot_summary_svg.py
+++ b/benchmarks/plot_summary_svg.py
@@ -45,34 +45,51 @@ PANEL_HEIGHT = 270
 PANEL_WIDTH = (WIDTH - PADDING * 2 - PANEL_GAP) / 2
 BAR_GAP = 6
 BAR_WIDTH = 24
-AXIS_COLOR = "#d5d8df"
-GRID_COLOR = "#eceef2"
-TEXT_COLOR = "#1c1f24"
-MUTED = "#5d6674"
+BG_COLOR = "var(--bg)"
+PANEL_COLOR = "var(--panel)"
+PANEL_STROKE = "var(--panel-stroke)"
+AXIS_COLOR = "var(--axis)"
+GRID_COLOR = "var(--grid)"
+TEXT_COLOR = "var(--text)"
+MUTED = "var(--muted)"
+FAIL_FILL = "var(--fail-fill)"
+FAIL_STROKE = "var(--fail-stroke)"
+FAIL_TEXT = "var(--fail-text)"
 FONT = "ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
-STYLE = """\
+
+
+def style_block():
+    return """
 <style>
   svg {
     color-scheme: light dark;
-  }
-
-  .chart-background {
-    fill: #0f172a;
-    fill-opacity: 0.1;
+    --bg: rgba(15, 23, 42, 0.10);
+    --panel: rgba(250, 251, 252, 0.92);
+    --panel-stroke: #e4e7ec;
+    --grid: #eceef2;
+    --axis: #d5d8df;
+    --text: #1c1f24;
+    --muted: #5d6674;
+    --fail-fill: rgba(255, 255, 255, 0.9);
+    --fail-stroke: #c7cdd8;
+    --fail-text: #b42318;
   }
 
   @media (prefers-color-scheme: dark) {
-    .chart-body {
-      filter: invert(1) hue-rotate(180deg);
-    }
-
-    .chart-background {
-      fill: #f8fafc;
-      fill-opacity: 0.08;
+    svg {
+      --bg: rgba(248, 250, 252, 0.08);
+      --panel: rgba(21, 26, 35, 0.88);
+      --panel-stroke: #2f3847;
+      --grid: #2a3140;
+      --axis: #3a4456;
+      --text: #f3f5f8;
+      --muted: #b7bfcb;
+      --fail-fill: rgba(255, 255, 255, 0.06);
+      --fail-stroke: #8f9bad;
+      --fail-text: #f6c3be;
     }
   }
-</style>
-"""
+</style>""".strip()
 
 
 def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR):
@@ -83,13 +100,12 @@ def svg_text(x, y, text, size=14, weight="400", anchor="start", fill=TEXT_COLOR)
     )
 
 
-def svg_rect(x, y, width, height, fill, rx=8, stroke="none", dash=None, opacity=None, class_name=None):
-    class_attr = f' class="{class_name}"' if class_name else ""
+def svg_rect(x, y, width, height, fill, rx=8, stroke="none", dash=None, opacity=None):
     dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
     opacity_attr = f' opacity="{opacity}"' if opacity is not None else ""
     return (
         f'<rect x="{x}" y="{y}" width="{width}" height="{height}" rx="{rx}" '
-        f'fill="{fill}" stroke="{stroke}"{class_attr}{dash_attr}{opacity_attr} />'
+        f'fill="{fill}" stroke="{stroke}"{dash_attr}{opacity_attr} />'
     )
 
 
@@ -98,7 +114,7 @@ def panel_origin(index):
 
 
 def draw_panel_frame(elements, x, y, width, height, title, subtitle):
-    elements.append(svg_rect(x, y, width, height, "#fafbfc", rx=14, stroke="#e4e7ec"))
+    elements.append(svg_rect(x, y, width, height, PANEL_COLOR, rx=14, stroke=PANEL_STROKE))
     elements.append(svg_text(x + 18, y + 28, title, size=16, weight="600"))
     elements.append(svg_text(x + 18, y + 48, subtitle, size=12, fill=MUTED))
 
@@ -152,8 +168,8 @@ def draw_compression_panel(elements, x, y, width, height, title, subtitle, packa
             if value is None:
                 fail_height = 24
                 fail_y = axis_bottom - fail_height
-                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, "#ffffff", rx=5, stroke="#c7cdd8", dash="4 4"))
-                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill="#b42318"))
+                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, FAIL_FILL, rx=5, stroke=FAIL_STROKE, dash="4 4"))
+                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill=FAIL_TEXT))
                 continue
             bar_height = axis_height * (value / max_value)
             bar_y = axis_bottom - bar_height
@@ -194,8 +210,8 @@ def draw_speed_panel(elements):
             if value is None:
                 fail_height = 24
                 fail_y = axis_bottom - fail_height
-                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, "#ffffff", rx=5, stroke="#c7cdd8", dash="4 4"))
-                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill="#b42318"))
+                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, FAIL_FILL, rx=5, stroke=FAIL_STROKE, dash="4 4"))
+                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, "fail", size=10, weight="600", anchor="middle", fill=FAIL_TEXT))
                 continue
             fraction = (math.log10(value) - log_min) / (log_max - log_min)
             bar_height = max(axis_height * fraction, 4)
@@ -208,9 +224,8 @@ def draw_speed_panel(elements):
 def build_svg():
     elements = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" fill="none">',
-        STYLE.strip(),
-        svg_rect(0, 0, WIDTH, HEIGHT, "#0f172a", rx=22, class_name="chart-background"),
-        '<g class="chart-body">',
+        style_block(),
+        svg_rect(0, 0, WIDTH, HEIGHT, BG_COLOR, rx=22),
         svg_text(PADDING, TITLE_Y, "pymini Benchmark Snapshot", size=24, weight="700"),
         svg_text(
             PADDING,
@@ -231,7 +246,6 @@ def build_svg():
         PACKAGES,
     )
     draw_speed_panel(elements)
-    elements.append("</g>")
     elements.append("</svg>")
     return "\n".join(elements)
 

--- a/benchmarks/summary.svg
+++ b/benchmarks/summary.svg
@@ -2,43 +2,37 @@
 <style>
   svg {
     color-scheme: light dark;
-    --bg: rgba(15, 23, 42, 0.10);
-    --panel: rgba(250, 251, 252, 0.92);
+    --bg: #ffffff;
+    --panel: #fafbfc;
     --panel-stroke: #e4e7ec;
     --grid: #eceef2;
     --axis: #d5d8df;
     --text: #1c1f24;
     --muted: #5d6674;
-    --fail-fill: rgba(255, 255, 255, 0.9);
-    --fail-stroke: #c7cdd8;
-    --fail-text: #b42318;
   }
 
   @media (prefers-color-scheme: dark) {
     svg {
-      --bg: rgba(248, 250, 252, 0.08);
-      --panel: rgba(21, 26, 35, 0.88);
+      --bg: #0e1117;
+      --panel: #151a23;
       --panel-stroke: #2f3847;
       --grid: #2a3140;
       --axis: #3a4456;
       --text: #f3f5f8;
       --muted: #b7bfcb;
-      --fail-fill: rgba(255, 255, 255, 0.06);
-      --fail-stroke: #8f9bad;
-      --fail-text: #f6c3be;
     }
   }
 </style>
-<rect x="0" y="0" width="980" height="430" rx="22" fill="var(--bg)" stroke="none" />
+<rect x="0" y="0" width="980" height="430" rx="0" fill="var(--bg)" stroke="none" stroke-width="1" />
 <text x="36" y="32" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" text-anchor="start">pymini Benchmark Snapshot</text>
 <text x="36" y="54" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="400" text-anchor="start">Validated package benchmarks from benchmarks/README.md, measured locally on April 7, 2026</text>
-<rect x="36" y="66" width="14" height="14" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="36" y="66" width="14" height="14" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="58" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pymini</text>
-<rect x="184" y="66" width="14" height="14" rx="4" fill="#6e7c91" stroke="none" />
+<rect x="184" y="66" width="14" height="14" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
 <text x="206" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">pyminifier</text>
-<rect x="332" y="66" width="14" height="14" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="332" y="66" width="14" height="14" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="354" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">python-minifier</text>
-<rect x="36.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" />
+<rect x="36.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" stroke-width="1" />
 <text x="54.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Compression</text>
 <text x="54.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Minify-only compression multiplier by package; higher is better</text>
 <line x1="90.0" y1="320.0" x2="460.0" y2="320.0" stroke="var(--grid)" />
@@ -53,28 +47,28 @@
 <text x="80.0" y="188.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">4x</text>
 <line x1="90.0" y1="184" x2="90.0" y2="320" stroke="var(--axis)" />
 <line x1="90.0" y1="320" x2="460.0" y2="320" stroke="var(--axis)" />
-<rect x="109.66666666666666" y="184.0" width="24" height="136.0" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="109.66666666666666" y="184.0" width="24" height="136.0" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="121.66666666666666" y="174.0" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">4.0x</text>
-<rect x="139.66666666666666" y="224.8" width="24" height="95.19999999999999" rx="4" fill="#6e7c91" stroke="none" />
+<rect x="139.66666666666666" y="224.8" width="24" height="95.19999999999999" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
 <text x="151.66666666666666" y="214.8" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.8x</text>
-<rect x="169.66666666666666" y="279.2" width="24" height="40.8" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="169.66666666666666" y="279.2" width="24" height="40.8" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="181.66666666666666" y="269.2" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
 <text x="151.66666666666666" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
-<rect x="232.99999999999997" y="255.4" width="24" height="64.6" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="232.99999999999997" y="255.4" width="24" height="64.6" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="244.99999999999997" y="245.4" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.9x</text>
-<rect x="263.0" y="279.2" width="24" height="40.8" rx="4" fill="#6e7c91" stroke="none" />
+<rect x="263.0" y="279.2" width="24" height="40.8" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
 <text x="275.0" y="269.2" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.2x</text>
-<rect x="293.0" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="293.0" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="305.0" y="255.60000000000002" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
 <text x="275.0" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
-<rect x="356.3333333333333" y="231.6" width="24" height="88.4" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="356.3333333333333" y="231.6" width="24" height="88.4" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="368.3333333333333" y="221.6" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">2.6x</text>
-<rect x="386.3333333333333" y="296" width="24" height="24" rx="5" fill="var(--fail-fill)" stroke="var(--fail-stroke)" stroke-dasharray="4 4" />
-<text x="398.3333333333333" y="286" fill="var(--fail-text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
-<rect x="416.3333333333333" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="386.3333333333333" y="296" width="24" height="24" rx="5" fill="none" stroke="#6e7c91" stroke-width="1.5" stroke-dasharray="6 4" />
+<text x="398.3333333333333" y="286" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
+<rect x="416.3333333333333" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="428.3333333333333" y="255.60000000000002" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
 <text x="398.3333333333333" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
-<rect x="504.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" />
+<rect x="504.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" stroke-width="1" />
 <text x="522.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Speed</text>
 <text x="522.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Mean package minification time; lower is better (log scale)</text>
 <line x1="558.0" y1="313.4101191154522" x2="928.0" y2="313.4101191154522" stroke="var(--grid)" />
@@ -89,25 +83,25 @@
 <text x="548.0" y="196.4958340893644" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3000 ms</text>
 <line x1="558.0" y1="184" x2="558.0" y2="320" stroke="var(--axis)" />
 <line x1="558.0" y1="320" x2="928.0" y2="320" stroke="var(--axis)" />
-<rect x="577.6666666666666" y="286.3738336008602" width="24" height="33.62616639913979" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="577.6666666666666" y="286.3738336008602" width="24" height="33.62616639913979" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="589.6666666666666" y="276.3738336008602" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">124.9 ms</text>
-<rect x="607.6666666666666" y="312.1384852061476" width="24" height="7.861514793852387" rx="4" fill="#6e7c91" stroke="none" />
+<rect x="607.6666666666666" y="312.1384852061476" width="24" height="7.861514793852387" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
 <text x="619.6666666666666" y="302.1384852061476" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">52.2 ms</text>
-<rect x="637.6666666666666" y="288.2530018159205" width="24" height="31.746998184079466" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="637.6666666666666" y="288.2530018159205" width="24" height="31.746998184079466" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="649.6666666666666" y="278.2530018159205" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">117.2 ms</text>
 <text x="619.6666666666666" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
-<rect x="701.0" y="255.7751782937885" width="24" height="64.22482170621149" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="701.0" y="255.7751782937885" width="24" height="64.22482170621149" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="713.0" y="245.7751782937885" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">352.0 ms</text>
-<rect x="731.0" y="303.05451169740434" width="24" height="16.94548830259568" rx="4" fill="#6e7c91" stroke="none" />
+<rect x="731.0" y="303.05451169740434" width="24" height="16.94548830259568" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
 <text x="743.0" y="293.05451169740434" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">71.0 ms</text>
-<rect x="761.0" y="264.0481281193889" width="24" height="55.95187188061112" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="761.0" y="264.0481281193889" width="24" height="55.95187188061112" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="773.0" y="254.04812811938888" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">266.0 ms</text>
 <text x="743.0" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
-<rect x="824.3333333333333" y="189.8012935481831" width="24" height="130.1987064518169" rx="4" fill="#1f7a5a" stroke="none" />
+<rect x="824.3333333333333" y="189.8012935481831" width="24" height="130.1987064518169" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
 <text x="836.3333333333333" y="179.8012935481831" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3286.6 ms</text>
-<rect x="854.3333333333333" y="296" width="24" height="24" rx="5" fill="var(--fail-fill)" stroke="var(--fail-stroke)" stroke-dasharray="4 4" />
-<text x="866.3333333333333" y="286" fill="var(--fail-text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
-<rect x="884.3333333333333" y="206.9533398374209" width="24" height="113.04666016257909" rx="4" fill="#c06b3e" stroke="none" />
+<rect x="854.3333333333333" y="296" width="24" height="24" rx="5" fill="none" stroke="#6e7c91" stroke-width="1.5" stroke-dasharray="6 4" />
+<text x="866.3333333333333" y="286" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
+<rect x="884.3333333333333" y="206.9533398374209" width="24" height="113.04666016257909" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="896.3333333333333" y="196.9533398374209" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1838.7 ms</text>
 <text x="866.3333333333333" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
 </svg>


### PR DESCRIPTION
## Summary

Match the benchmark summary assets to the established TexSoup benchmark styling and naming.

## What Changed

- rename the generator to `benchmarks/plot.py`
- rename the checked-in image to `benchmarks/summary.svg`
- update `benchmarks/README.md` to embed `summary.svg`
- switch the chart theme colors to the same light/dark CSS variables used by `~/dev/TexSoup/benchmarks/plot.py`
- use the same fixed background treatment as the TexSoup benchmark assets

## Why

The prior follow-up used a custom dark-mode treatment and different asset names. This change brings the plot in line with the benchmark styling conventions already used in TexSoup.

## Impact

- the benchmark chart now matches the established benchmark visual language more closely
- the asset naming matches the TexSoup benchmark layout
- no runtime package behavior changes

## Validation

- ran `python3 benchmarks/plot.py`
- ran `xmllint --noout benchmarks/summary.svg`
- ran `git diff --check`
