### PR TITLE
Split benchmark chart into minification and compression

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,7 +9,7 @@ the benchmark harness used to reproduce them.
 
 # Results
 
-![Benchmark summary chart comparing minify-only compression and speed across packages](./summary.svg)
+![Benchmark summary chart comparing minify-only minification and minify-plus-wheel compression across packages](./summary.svg)
 
 ## Compression
 

--- a/benchmarks/plot.py
+++ b/benchmarks/plot.py
@@ -12,7 +12,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import math
 from pathlib import Path
 from xml.sax.saxutils import escape
 
@@ -25,18 +24,18 @@ TOOLS = (
 PACKAGES = (
     {
         "name": "TexSoup",
-        "speed_ms": {"pymini": 124.9, "pyminifier": 52.2, "python-minifier": 117.2},
-        "compression_x": {"pymini": 4.0, "pyminifier": 2.8, "python-minifier": 1.2},
+        "minify_x": {"pymini": 4.0, "pyminifier": 2.8, "python-minifier": 1.2},
+        "wheel_x": {"pymini": 7.3, "pyminifier": 6.6, "python-minifier": 3.6},
     },
     {
         "name": "timefhuman",
-        "speed_ms": {"pymini": 352.0, "pyminifier": 71.0, "python-minifier": 266.0},
-        "compression_x": {"pymini": 1.9, "pyminifier": 1.2, "python-minifier": 1.6},
+        "minify_x": {"pymini": 1.9, "pyminifier": 1.2, "python-minifier": 1.6},
+        "wheel_x": {"pymini": 3.4, "pyminifier": 3.1, "python-minifier": 3.2},
     },
     {
         "name": "rich",
-        "speed_ms": {"pymini": 3286.6, "pyminifier": None, "python-minifier": 1838.7},
-        "compression_x": {"pymini": 2.6, "pyminifier": None, "python-minifier": 1.6},
+        "minify_x": {"pymini": 2.6, "pyminifier": None, "python-minifier": 1.6},
+        "wheel_x": {"pymini": 6.6, "pyminifier": None, "python-minifier": 4.6},
     },
 )
 
@@ -149,7 +148,7 @@ def group_start_x(axis_left, group_width, group_index, cluster_width):
     return axis_left + group_width * group_index + (group_width - cluster_width) / 2
 
 
-def draw_compression_panel(elements, x, y, width, height, title, subtitle, packages, max_value=4.0):
+def draw_multiplier_panel(elements, x, y, width, height, title, subtitle, packages, key, max_value, tick_values):
     draw_panel_frame(elements, x, y, width, height, title, subtitle)
     axis_left = x + 54
     axis_right = x + width - 16
@@ -157,7 +156,7 @@ def draw_compression_panel(elements, x, y, width, height, title, subtitle, packa
     axis_bottom = y + height - 52
     axis_height = axis_bottom - axis_top
 
-    for tick in (0, 1, 2, 3, 4):
+    for tick in tick_values:
         tick_y = axis_bottom - axis_height * (tick / max_value)
         elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID}" />')
         elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick}x", size=11, anchor='end', fill=MUTED))
@@ -171,7 +170,7 @@ def draw_compression_panel(elements, x, y, width, height, title, subtitle, packa
         center = group_center(axis_left, group_width, group_index)
         start_x = group_start_x(axis_left, group_width, group_index, cluster_width)
         for tool_index, tool in enumerate(TOOLS):
-            value = package["compression_x"][tool["name"]]
+            value = package[key][tool["name"]]
             bar_x = start_x + tool_index * (BAR_WIDTH + BAR_GAP)
             if value is None:
                 fail_height = 24
@@ -186,47 +185,21 @@ def draw_compression_panel(elements, x, y, width, height, title, subtitle, packa
         elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor='middle', fill=MUTED))
 
 
-def draw_speed_panel(elements):
+def draw_wheel_panel(elements):
     x, y = panel_origin(1)
-    draw_panel_frame(elements, x, y, PANEL_WIDTH, PANEL_HEIGHT, 'Speed', 'Mean package minification time; lower is better (log scale)')
-    axis_left = x + 54
-    axis_right = x + PANEL_WIDTH - 16
-    axis_top = y + 82
-    axis_bottom = y + PANEL_HEIGHT - 52
-    axis_height = axis_bottom - axis_top
-    log_min = math.log10(40)
-    log_max = math.log10(4000)
-    ticks = (50, 100, 500, 1000, 3000)
-
-    for tick in ticks:
-        fraction = (math.log10(tick) - log_min) / (log_max - log_min)
-        tick_y = axis_bottom - axis_height * fraction
-        elements.append(f'<line x1="{axis_left}" y1="{tick_y}" x2="{axis_right}" y2="{tick_y}" stroke="{GRID}" />')
-        elements.append(svg_text(axis_left - 10, tick_y + 4, f"{tick:g} ms", size=11, anchor='end', fill=MUTED))
-
-    elements.append(f'<line x1="{axis_left}" y1="{axis_top}" x2="{axis_left}" y2="{axis_bottom}" stroke="{AXIS}" />')
-    elements.append(f'<line x1="{axis_left}" y1="{axis_bottom}" x2="{axis_right}" y2="{axis_bottom}" stroke="{AXIS}" />')
-
-    group_width, cluster_width = layout_groups(axis_left, axis_right, len(PACKAGES))
-
-    for group_index, package in enumerate(PACKAGES):
-        center = group_center(axis_left, group_width, group_index)
-        start_x = group_start_x(axis_left, group_width, group_index, cluster_width)
-        for tool_index, tool in enumerate(TOOLS):
-            value = package["speed_ms"][tool["name"]]
-            bar_x = start_x + tool_index * (BAR_WIDTH + BAR_GAP)
-            if value is None:
-                fail_height = 24
-                fail_y = axis_bottom - fail_height
-                elements.append(svg_rect(bar_x, fail_y, BAR_WIDTH, fail_height, 'none', rx=5, stroke=tool["color"], stroke_width=1.5, dash='6 4'))
-                elements.append(svg_text(bar_x + BAR_WIDTH / 2, fail_y - 10, 'fail', size=10, weight='600', anchor='middle', fill=MUTED))
-                continue
-            fraction = (math.log10(value) - log_min) / (log_max - log_min)
-            bar_height = max(axis_height * fraction, 4)
-            bar_y = axis_bottom - bar_height
-            elements.append(svg_rect(bar_x, bar_y, BAR_WIDTH, bar_height, tool["color"], rx=4))
-            elements.append(svg_text(bar_x + BAR_WIDTH / 2, bar_y - 10, f"{value:.1f} ms", size=10, weight='600', anchor='middle'))
-        elements.append(svg_text(center, axis_bottom + 20, package["name"], size=11, anchor='middle', fill=MUTED))
+    draw_multiplier_panel(
+        elements,
+        x,
+        y,
+        PANEL_WIDTH,
+        PANEL_HEIGHT,
+        'Compression',
+        'Minify + wheel compression multiplier by package; higher is better',
+        PACKAGES,
+        'wheel_x',
+        8.0,
+        (0, 2, 4, 6, 8),
+    )
 
 
 def build_svg():
@@ -244,16 +217,19 @@ def build_svg():
         ),
     ]
     draw_legend(elements)
-    draw_compression_panel(
+    draw_multiplier_panel(
         elements,
         *panel_origin(0),
         PANEL_WIDTH,
         PANEL_HEIGHT,
-        'Compression',
+        'Minification',
         'Minify-only compression multiplier by package; higher is better',
         PACKAGES,
+        'minify_x',
+        4.0,
+        (0, 1, 2, 3, 4),
     )
-    draw_speed_panel(elements)
+    draw_wheel_panel(elements)
     elements.append('</svg>')
     return "\n".join(elements)
 

--- a/benchmarks/summary.svg
+++ b/benchmarks/summary.svg
@@ -33,7 +33,7 @@
 <rect x="332" y="66" width="14" height="14" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
 <text x="354" y="78" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">python-minifier</text>
 <rect x="36.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" stroke-width="1" />
-<text x="54.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Compression</text>
+<text x="54.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Minification</text>
 <text x="54.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Minify-only compression multiplier by package; higher is better</text>
 <line x1="90.0" y1="320.0" x2="460.0" y2="320.0" stroke="var(--grid)" />
 <text x="80.0" y="324.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">0x</text>
@@ -69,39 +69,39 @@
 <text x="428.3333333333333" y="255.60000000000002" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1.6x</text>
 <text x="398.3333333333333" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
 <rect x="504.0" y="102" width="440.0" height="270" rx="14" fill="var(--panel)" stroke="var(--panel-stroke)" stroke-width="1" />
-<text x="522.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Speed</text>
-<text x="522.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Mean package minification time; lower is better (log scale)</text>
-<line x1="558.0" y1="313.4101191154522" x2="928.0" y2="313.4101191154522" stroke="var(--grid)" />
-<text x="548.0" y="317.4101191154522" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">50 ms</text>
-<line x1="558.0" y1="292.94007941030145" x2="928.0" y2="292.94007941030145" stroke="var(--grid)" />
-<text x="548.0" y="296.94007941030145" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">100 ms</text>
-<line x1="558.0" y1="245.41011911545218" x2="928.0" y2="245.41011911545218" stroke="var(--grid)" />
-<text x="548.0" y="249.41011911545218" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">500 ms</text>
-<line x1="558.0" y1="224.94007941030145" x2="928.0" y2="224.94007941030145" stroke="var(--grid)" />
-<text x="548.0" y="228.94007941030145" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">1000 ms</text>
-<line x1="558.0" y1="192.4958340893644" x2="928.0" y2="192.4958340893644" stroke="var(--grid)" />
-<text x="548.0" y="196.4958340893644" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">3000 ms</text>
+<text x="522.0" y="130" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="600" text-anchor="start">Compression</text>
+<text x="522.0" y="150" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="12" font-weight="400" text-anchor="start">Minify + wheel compression multiplier by package; higher is better</text>
+<line x1="558.0" y1="320.0" x2="928.0" y2="320.0" stroke="var(--grid)" />
+<text x="548.0" y="324.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">0x</text>
+<line x1="558.0" y1="286.0" x2="928.0" y2="286.0" stroke="var(--grid)" />
+<text x="548.0" y="290.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">2x</text>
+<line x1="558.0" y1="252.0" x2="928.0" y2="252.0" stroke="var(--grid)" />
+<text x="548.0" y="256.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">4x</text>
+<line x1="558.0" y1="218.0" x2="928.0" y2="218.0" stroke="var(--grid)" />
+<text x="548.0" y="222.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">6x</text>
+<line x1="558.0" y1="184.0" x2="928.0" y2="184.0" stroke="var(--grid)" />
+<text x="548.0" y="188.0" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="end">8x</text>
 <line x1="558.0" y1="184" x2="558.0" y2="320" stroke="var(--axis)" />
 <line x1="558.0" y1="320" x2="928.0" y2="320" stroke="var(--axis)" />
-<rect x="577.6666666666666" y="286.3738336008602" width="24" height="33.62616639913979" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
-<text x="589.6666666666666" y="276.3738336008602" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">124.9 ms</text>
-<rect x="607.6666666666666" y="312.1384852061476" width="24" height="7.861514793852387" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
-<text x="619.6666666666666" y="302.1384852061476" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">52.2 ms</text>
-<rect x="637.6666666666666" y="288.2530018159205" width="24" height="31.746998184079466" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
-<text x="649.6666666666666" y="278.2530018159205" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">117.2 ms</text>
+<rect x="577.6666666666666" y="195.9" width="24" height="124.1" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
+<text x="589.6666666666666" y="185.9" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">7.3x</text>
+<rect x="607.6666666666666" y="207.8" width="24" height="112.19999999999999" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
+<text x="619.6666666666666" y="197.8" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">6.6x</text>
+<rect x="637.6666666666666" y="258.8" width="24" height="61.2" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
+<text x="649.6666666666666" y="248.8" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3.6x</text>
 <text x="619.6666666666666" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">TexSoup</text>
-<rect x="701.0" y="255.7751782937885" width="24" height="64.22482170621149" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
-<text x="713.0" y="245.7751782937885" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">352.0 ms</text>
-<rect x="731.0" y="303.05451169740434" width="24" height="16.94548830259568" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
-<text x="743.0" y="293.05451169740434" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">71.0 ms</text>
-<rect x="761.0" y="264.0481281193889" width="24" height="55.95187188061112" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
-<text x="773.0" y="254.04812811938888" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">266.0 ms</text>
+<rect x="701.0" y="262.2" width="24" height="57.8" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
+<text x="713.0" y="252.2" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3.4x</text>
+<rect x="731.0" y="267.3" width="24" height="52.7" rx="4" fill="#6e7c91" stroke="none" stroke-width="1" />
+<text x="743.0" y="257.3" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3.1x</text>
+<rect x="761.0" y="265.6" width="24" height="54.400000000000006" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
+<text x="773.0" y="255.60000000000002" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3.2x</text>
 <text x="743.0" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">timefhuman</text>
-<rect x="824.3333333333333" y="189.8012935481831" width="24" height="130.1987064518169" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
-<text x="836.3333333333333" y="179.8012935481831" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">3286.6 ms</text>
+<rect x="824.3333333333333" y="207.8" width="24" height="112.19999999999999" rx="4" fill="#1f7a5a" stroke="none" stroke-width="1" />
+<text x="836.3333333333333" y="197.8" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">6.6x</text>
 <rect x="854.3333333333333" y="296" width="24" height="24" rx="5" fill="none" stroke="#6e7c91" stroke-width="1.5" stroke-dasharray="6 4" />
 <text x="866.3333333333333" y="286" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">fail</text>
-<rect x="884.3333333333333" y="206.9533398374209" width="24" height="113.04666016257909" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
-<text x="896.3333333333333" y="196.9533398374209" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">1838.7 ms</text>
+<rect x="884.3333333333333" y="241.8" width="24" height="78.19999999999999" rx="4" fill="#c06b3e" stroke="none" stroke-width="1" />
+<text x="896.3333333333333" y="231.8" fill="var(--text)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" font-weight="600" text-anchor="middle">4.6x</text>
 <text x="866.3333333333333" y="340" fill="var(--muted)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="11" font-weight="400" text-anchor="middle">rich</text>
 </svg>


### PR DESCRIPTION
## Summary

Refresh the benchmark summary figure so both panels focus on compression outcomes instead of mixing compression and runtime.

## What Changed

- relabel the left panel as `Minification` while keeping the current minify-only data and layout
- replace the right panel with minify-plus-wheel compression data from `benchmarks/README.md`
- regenerate `benchmarks/summary.svg` from `benchmarks/plot.py`
- update the README image alt text to match the new figure content

## Why

The previous chart mixed two different dimensions: minify-only compression on the left and runtime on the right. This follow-up makes the figure compare two compression-oriented views side by side.

## Impact

- readers can compare raw minification against minify-plus-wheel compression in one figure
- the checked-in SVG remains reproducible from the stdlib-only generator
- no runtime package behavior changes

## Validation

- ran `python3 benchmarks/plot.py`
- ran `xmllint --noout benchmarks/summary.svg`
- ran `git diff --check`
