### PR TITLE
Make fast compression the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Bundle mode emits one file:
 pymini bundle src -o out/bundle.py
 ```
 
+The default profile now favors speed. To run the slower full pipeline with
+extra compression passes, use:
+
+```bash
+pymini package src --slow -o out
+```
+
 You can also use the Python API directly:
 
 ```python
@@ -36,10 +43,16 @@ sources, modules = minify(
 )
 ```
 
+To use the slower profile through the API:
+
+```python
+sources, modules = minify(..., fast=False)
+```
+
 # Compression
 
 Representative compression results, using
-`--rename-modules --rename-global-variables --rename-arguments`:
+`--slow --rename-modules --rename-global-variables --rename-arguments`:
 
 ![Benchmark summary chart comparing minify-only minification and minify-plus-wheel compression across packages](./benchmarks/summary.svg)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,6 +11,16 @@ the benchmark harness used to reproduce them.
 
 ![Benchmark summary chart comparing minify-only minification and minify-plus-wheel compression across packages](./summary.svg)
 
+## Profiles
+
+`pymini` now defaults to the faster profile. The slower full pipeline is still
+available with `pymini ... --slow` or `minify(..., fast=False)`.
+
+Those extra hoisting and aliasing passes are input-sensitive: they help some
+inputs, do nothing on some, and can slightly increase output on others. The
+package size tables below keep using the slower profile so they stay directly
+comparable with earlier revisions.
+
 ## Compression
 
 Compression multipliers below are all relative to the original raw Python
@@ -78,7 +88,8 @@ repo's actual packaging metadata.
 | pyminifier | 79,693 | 61,088 | 64,019 | 76,101 |
 | rich | 310,458 | 183,326 | failed | 266,399 |
 
-`pymini` is benchmarked with `--rename-modules --rename-global-variables --rename-arguments`.
+The `pymini` compression tables above use
+`--slow --rename-modules --rename-global-variables --rename-arguments`.
 The `pymini` rows use package mode. The baselines minify each file
 independently in the preserved package tree. For wheel rows, each tool first
 rewrites the package tree, then `python -m build --wheel` runs on that
@@ -95,27 +106,23 @@ Wheel-specific failures:
 
 ## Speed
 
-| Input | pymini | pyminifier | python-minifier |
-| --- | ---: | ---: | ---: |
-| pyminifier.py | 3.0 ms | 0.8 ms | 2.6 ms |
-| pyminify.py | 7.9 ms | 2.0 ms | 6.7 ms |
-| click | 855.2 ms | failed | 823.9 ms |
-| pytest | 3.258 s | failed | 3.156 s |
-| TexSoup | 218.6 ms | failed | 251.1 ms |
-| timefhuman | 441.5 ms | failed | 450.6 ms |
-| pyminifier | 196.7 ms | 68.5 ms | 191.7 ms |
-| rich | 3.226 s | failed | 3.080 s |
+The current default favors speed. On the checked-in fixtures, the slower
+profile adds about 25-65% runtime.
 
-pyminifier minification fails on `__init__.py` with
-  `TypeError: 'NoneType' object is not subscriptable`.
+| Input | pymini | pymini --slow | pymini bytes | pymini --slow bytes |
+| --- | ---: | ---: | ---: | ---: |
+| pyminifier.py | 3.0 ms | 3.5 ms | 435 | 435 |
+| pyminify.py | 5.3 ms | 7.9 ms | 1,242 | 935 |
+| click | 677.8 ms | 913.7 ms | 120,579 | 121,176 |
+| pytest | 2.797 s | 3.669 s | 503,996 | 508,888 |
+| pyminifier | 142.9 ms | 194.8 ms | 31,481 | 31,332 |
 
-The single-file rows come from [benchmark_speed.py](./benchmark_speed.py). The
-package rows are averages of three fresh-process runs from the same
-environment used for the compression comparison. `pymini` used package mode
-with `--rename-modules --rename-global-variables --rename-arguments`, while
-the baseline tools minified each file independently in the preserved package
-tree. The `click`, `pytest`, and `pyminifier` rows use the checked-in fixtures
-under `.bench-repos`; the other package rows use local package checkouts.
+The single-file rows come from [benchmark_speed.py](./benchmark_speed.py).
+The package rows above use the checked-in fixtures under `.bench-repos`.
+
+The slower extra passes are not monotonic: `pyminify.py` and the
+`pyminifier` package shrink a bit more, while `click` and `pytest` end up
+slightly larger.
 
 # Reproduce
 
@@ -123,8 +130,7 @@ Recompute the speed measurements with:
 
 ```bash
 python3 -m pip install -e ".[dev]" python-minifier
-git clone https://github.com/liftoff/pyminifier /tmp/pyminifier
-PYTHONPATH=. .venv/bin/python benchmarks/benchmark_speed.py --pyminifier-root /tmp/pyminifier
+PYTHONPATH=. .venv/bin/python benchmarks/benchmark_speed.py
 ```
 
 The larger package comparisons in this file were run against these checkouts:
@@ -140,6 +146,9 @@ The larger package comparisons in this file were run against these checkouts:
 
 Each package result above was checked against the repo's own test suite using a
 temporary minified package tree on `PYTHONPATH`.
+
+These validation rows correspond to the same `pymini --slow` rewrites used for
+the compression tables above.
 
 | Package | pymini | pyminifier | python-minifier |
 | --- | --- | --- | --- |
@@ -161,7 +170,7 @@ To reproduce that flow locally:
 ```bash
 git clone https://github.com/alvinwan/TexSoup /tmp/texsoup
 mkdir -p /tmp/texsoup-out/TexSoup
-pymini package /tmp/texsoup/TexSoup -o /tmp/texsoup-out/TexSoup --rename-modules --rename-global-variables --rename-arguments
+pymini package /tmp/texsoup/TexSoup -o /tmp/texsoup-out/TexSoup --slow --rename-modules --rename-global-variables --rename-arguments
 cp -R /tmp/texsoup/tests /tmp/texsoup-tests
 PYTHONPATH=/tmp/texsoup-out:/tmp/texsoup-tests python3 -m pytest /tmp/texsoup-tests/tests -o addopts=''
 ```

--- a/benchmarks/benchmark_speed.py
+++ b/benchmarks/benchmark_speed.py
@@ -18,11 +18,15 @@ from pymini.cli import load_sources, main as cli_main, resolve_python_files
 ROOT = Path(__file__).resolve().parents[1]
 EXAMPLE_DIR = ROOT / "tests" / "examples"
 DEFAULT_TEXSOUP_ROOT = Path("/tmp/pymini-texsoup-repo/TexSoup")
-DEFAULT_PYMINIFIER_ROOT = Path("/tmp/pymini-pyminifier-src/pyminifier-2.1")
-PYMINI_AGGRESSIVE_OPTIONS = {
+DEFAULT_PYMINIFIER_ROOT = ROOT / ".bench-repos" / "pyminifier-tool"
+PYMINI_DEFAULT_OPTIONS = {
     "keep_module_names": False,
     "keep_global_variables": False,
     "rename_arguments": True,
+}
+PYMINI_SLOW_OPTIONS = {
+    **PYMINI_DEFAULT_OPTIONS,
+    "fast": False,
 }
 
 
@@ -50,13 +54,14 @@ def benchmark_transform(
     }
 
 
-def pymini_single_file_transform(path: Path):
+def pymini_single_file_transform(path: Path, *, fast: bool = True):
     def transform(source: str) -> str:
         outputs, _ = minify(
             source,
             path.stem,
             keep_global_variables=False,
             rename_arguments=True,
+            fast=fast,
         )
         return outputs[0]
 
@@ -101,14 +106,16 @@ def benchmark_package_api(
     *,
     iterations: int,
     warmup: int,
+    fast: bool = True,
 ) -> dict[str, float]:
     paths, module_root = resolve_python_files(str(package_root))
     sources, modules, _ = load_sources(paths, module_root=module_root)
+    options = PYMINI_DEFAULT_OPTIONS if fast else PYMINI_SLOW_OPTIONS
     for _ in range(warmup):
         minify(
             sources,
             modules,
-            **PYMINI_AGGRESSIVE_OPTIONS,
+            **options,
         )
     samples = []
     outputs = None
@@ -117,7 +124,7 @@ def benchmark_package_api(
         outputs, _ = minify(
             sources,
             modules,
-            **PYMINI_AGGRESSIVE_OPTIONS,
+            **options,
         )
         samples.append(perf_counter() - start)
     raw_bytes = sum(len(source.encode()) for source in sources)
@@ -132,24 +139,25 @@ def benchmark_package_api(
     }
 
 
-def benchmark_package_cli(package_root: Path, *, iterations: int) -> dict[str, float]:
+def benchmark_package_cli(package_root: Path, *, iterations: int, fast: bool = True) -> dict[str, float]:
     samples = []
     output_bytes = 0
     for _ in range(iterations):
         output_dir = Path(tempfile.mkdtemp(prefix="pymini-bench-"))
         try:
             start = perf_counter()
-            rc = cli_main(
-                [
-                    "package",
-                    str(package_root),
-                    "--rename-modules",
-                    "--rename-global-variables",
-                    "--rename-arguments",
-                    "-o",
-                    str(output_dir),
-                ]
-            )
+            argv = [
+                "package",
+                str(package_root),
+                "--rename-modules",
+                "--rename-global-variables",
+                "--rename-arguments",
+                "-o",
+                str(output_dir),
+            ]
+            if not fast:
+                argv.insert(-2, "--slow")
+            rc = cli_main(argv)
             samples.append(perf_counter() - start)
             if rc != 0:
                 raise RuntimeError(f"pymini CLI returned {rc}")
@@ -166,7 +174,10 @@ def print_example_results(
     warmup: int,
     pyminifier_root: Path,
 ) -> None:
-    tool_factories = [("pymini", pymini_single_file_transform)]
+    tool_factories = [
+        ("pymini", lambda path: pymini_single_file_transform(path, fast=True)),
+        ("pymini-slow", lambda path: pymini_single_file_transform(path, fast=False)),
+    ]
     python_minifier = load_python_minifier()
     if python_minifier is not None:
         tool_factories.append(("python-minifier", python_minifier))
@@ -210,10 +221,23 @@ def print_package_results(
         texsoup_root,
         iterations=package_api_iterations,
         warmup=warmup,
+        fast=True,
+    )
+    api_slow_result = benchmark_package_api(
+        texsoup_root,
+        iterations=package_api_iterations,
+        warmup=warmup,
+        fast=False,
     )
     cli_result = benchmark_package_cli(
         texsoup_root,
         iterations=package_cli_iterations,
+        fast=True,
+    )
+    cli_slow_result = benchmark_package_cli(
+        texsoup_root,
+        iterations=package_cli_iterations,
+        fast=False,
     )
 
     print()
@@ -228,8 +252,20 @@ def print_package_results(
         f"{api_result['throughput_kb_s']:.1f}"
     )
     print(
+        f"TexSoup-api-slow\t"
+        f"{int(api_slow_result['files'])}\t"
+        f"{int(api_slow_result['bytes'])}\t"
+        f"{int(api_slow_result['output_bytes'])}\t"
+        f"{api_slow_result['avg_ms']:.3f}\t"
+        f"{api_slow_result['throughput_kb_s']:.1f}"
+    )
+    print(
         f"TexSoup-cli\t-\t-\t{int(cli_result['output_bytes'])}\t"
         f"{cli_result['avg_ms']:.3f}\t-"
+    )
+    print(
+        f"TexSoup-cli-slow\t-\t-\t{int(cli_slow_result['output_bytes'])}\t"
+        f"{cli_slow_result['avg_ms']:.3f}\t-"
     )
 
 

--- a/pymini/cli.py
+++ b/pymini/cli.py
@@ -36,6 +36,20 @@ def build_parser() -> ArgumentParser:
         action='store_true',
         help='Rename function and method arguments, including internal keyword call sites when safe.',
     )
+    profile = parser.add_mutually_exclusive_group()
+    profile.add_argument(
+        '--fast',
+        dest='fast',
+        action='store_true',
+        help='Use the default faster profile.',
+    )
+    profile.add_argument(
+        '--slow',
+        dest='fast',
+        action='store_false',
+        help='Run the slower full pipeline with extra compression passes.',
+    )
+    parser.set_defaults(fast=True)
     parser.add_argument('--single-file', action='store_true', help=SUPPRESS)
     parser.add_argument('-o', '--output', help='Path to the output directory', default='./')
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
@@ -57,11 +71,18 @@ def effective_mode(args) -> str:
     return BUNDLE_MODE if args.single_file else args.mode
 
 
-def resolve_options(args) -> tuple[str, bool, bool, bool, bool]:
+def resolve_options(args) -> tuple[str, bool, bool, bool, bool, bool]:
     mode = effective_mode(args)
     keep_module_names = not args.rename_modules
     keep_global_variables = not args.rename_global_variables
-    return mode, keep_module_names, keep_global_variables, args.rename_arguments, mode == BUNDLE_MODE
+    return (
+        mode,
+        keep_module_names,
+        keep_global_variables,
+        args.rename_arguments,
+        args.fast,
+        mode == BUNDLE_MODE,
+    )
 
 
 def resolve_python_files(path: str) -> tuple[list[Path], Optional[Path]]:
@@ -168,7 +189,14 @@ def write_outputs(
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(normalize_argv(argv))
-    mode, keep_module_names, keep_global_variables, rename_arguments, output_single_file = resolve_options(args)
+    (
+        mode,
+        keep_module_names,
+        keep_global_variables,
+        rename_arguments,
+        fast,
+        output_single_file,
+    ) = resolve_options(args)
     paths, module_root = resolve_python_files(args.path)
     if not paths:
         parser.error(f"no Python files matched {args.path!r}")
@@ -185,6 +213,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         keep_module_names=keep_module_names,
         keep_global_variables=keep_global_variables,
         rename_arguments=rename_arguments,
+        fast=fast,
         output_single_file=output_single_file,
     )
     try:

--- a/pymini/pymini.py
+++ b/pymini/pymini.py
@@ -1346,6 +1346,7 @@ class FusedVariableShortener(Transformer):
         self.keep_module_names = keep_module_names
 
     def transform(self, *trees):
+        _invalidate_reserved_names_cache()
         original_modules = list(self.module_to_shortener)
         packages = package_modules(original_modules)
         module_to_module = {}
@@ -1437,21 +1438,39 @@ def _is_docstring_constant(node):
 
 
 def _reserved_names_in_node(node):
+    cached_version = getattr(node, "_pymini_reserved_names_version", None)
+    if cached_version == _RESERVED_NAMES_CACHE_VERSION:
+        return node._pymini_reserved_names
+
     names = set()
-    for current in ast.walk(node):
-        if isinstance(current, ast.Name):
-            names.add(current.id)
-        elif isinstance(current, ast.arg):
-            names.add(current.arg)
-        elif isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            names.add(current.name)
-        elif isinstance(current, ast.alias):
-            names.add(current.asname or current.name.split(".", 1)[0])
-        elif isinstance(current, (ast.Global, ast.Nonlocal)):
-            names.update(current.names)
-        elif isinstance(current, ast.ExceptHandler) and current.name:
-            names.add(current.name)
-    return names
+    if isinstance(node, ast.Name):
+        names.add(node.id)
+    elif isinstance(node, ast.arg):
+        names.add(node.arg)
+    elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        names.add(node.name)
+    elif isinstance(node, ast.alias):
+        names.add(node.asname or node.name.split(".", 1)[0])
+    elif isinstance(node, (ast.Global, ast.Nonlocal)):
+        names.update(node.names)
+    elif isinstance(node, ast.ExceptHandler) and node.name:
+        names.add(node.name)
+
+    for child in ast.iter_child_nodes(node):
+        names.update(_reserved_names_in_node(child))
+
+    cached = frozenset(names)
+    node._pymini_reserved_names = cached
+    node._pymini_reserved_names_version = _RESERVED_NAMES_CACHE_VERSION
+    return cached
+
+
+_RESERVED_NAMES_CACHE_VERSION = 0
+
+
+def _invalidate_reserved_names_cache():
+    global _RESERVED_NAMES_CACHE_VERSION
+    _RESERVED_NAMES_CACHE_VERSION += 1
 
 
 class RepeatedStringHoister(Transformer):
@@ -1460,6 +1479,7 @@ class RepeatedStringHoister(Transformer):
         self.generator = generator
 
     def transform(self, *trees):
+        _invalidate_reserved_names_cache()
         for tree in trees:
             ParentSetter().visit(tree)
             collector = RepeatedStringCollector()
@@ -1537,7 +1557,7 @@ class RepeatedStringRewriter(ast.NodeTransformer):
             scope_type = "class"
         else:
             scope_type = "function"
-        reserved_names = _reserved_names_in_node(node)
+        reserved_names = set(_reserved_names_in_node(node))
         return {
             value: self._next_safe_name(reserved_names)
             for value, count in counts.items()
@@ -1636,6 +1656,7 @@ class RepeatedNameAliaser(ast.NodeTransformer):
         self.generator = generator
 
     def transform(self, *trees):
+        _invalidate_reserved_names_cache()
         for tree in trees:
             self.visit(tree)
         return trees
@@ -1716,7 +1737,7 @@ class RepeatedNameCollector(ast.NodeVisitor):
         ]
         if not repeated:
             return {}
-        reserved_names = _reserved_names_in_node(statement)
+        reserved_names = set(_reserved_names_in_node(statement))
         return {
             name: allocator(reserved_names)
             for name in repeated
@@ -2304,7 +2325,7 @@ class WhitespaceRemover(NodeTransformer):
 
 def minify(sources, modules='main', keep_module_names=False,
            keep_global_variables=False, rename_arguments=False, output_single_file=False,
-           single_file_module='bundle'):
+           single_file_module='bundle', fast=True):
     """Uglify source code. Simplify, minify, and obfuscate.
 
     >>> sources, modules = minify(['''a = 3
@@ -2332,12 +2353,30 @@ def minify(sources, modules='main', keep_module_names=False,
     assert len(sources) == len(modules)
 
     trees = [ast.parse(source) for source in sources]
+    _invalidate_reserved_names_cache()
     reserved_names_by_module = [_reserved_names_in_node(tree) for tree in trees]
 
-    pipeline = Pipeline(
-
+    simplifier = ReturnSimplifier()
+    ind = IndependentVariableShorteners(
+        reserved_names_by_module=reserved_names_by_module,
+        modules=modules,
+        keep_global_variables=keep_global_variables,
+        rename_arguments=rename_arguments,
+        reuse_names_across_modules=not output_single_file,
+    )
+    fused = FusedVariableShortener(
+        generator=ind.generator,
+        module_to_shortener=ind.module_to_shortener,
+        modules=ind.modules,
+        keep_module_names=keep_module_names,
+    )
+    fuser = (
+        FileFuser(modules=fused.modules) if output_single_file
+        else Fuser(modules=fused.modules)
+    )
+    pipeline_steps = [
         # simplify
-        simplifier := ReturnSimplifier(),
+        simplifier,
         RemoveUnusedVariables(simplifier.unused_assignments),
 
         # minify
@@ -2345,33 +2384,24 @@ def minify(sources, modules='main', keep_module_names=False,
         CommentRemover(),
 
         # obfuscate
-        ind := IndependentVariableShorteners(
-            reserved_names_by_module=reserved_names_by_module,
-            modules=modules,
-            keep_global_variables=keep_global_variables,
-            rename_arguments=rename_arguments,
-            reuse_names_across_modules=not output_single_file,
-        ),  # obscure within files (but not across files)
-        fused := FusedVariableShortener(
-            generator=ind.generator,
-            module_to_shortener=ind.module_to_shortener,
-            modules=ind.modules,
-            keep_module_names=keep_module_names,
-        ),  # obfuscate across files
-        RepeatedStringHoister(ind.generator),
-        RepeatedNameAliaser(ind.generator),
-
+        ind,
+        fused,
+    ]
+    if not fast:
+        pipeline_steps.extend((
+            RepeatedStringHoister(ind.generator),
+            RepeatedNameAliaser(ind.generator),
+        ))
+    pipeline_steps.extend((
         # optionally fuse files
-        fuser := (
-            FileFuser(modules=fused.modules) if output_single_file
-            else Fuser(modules=fused.modules)
-        ),
+        fuser,
 
         # final post-processing to remove whitespace (minify)
         LocationFixer(),
         Unparser(),
         WhitespaceRemover(),
-    )
+    ))
+    pipeline = Pipeline(*pipeline_steps)
     cleaned = list(pipeline.transform(*trees))
     if output_single_file:
         cleaned = [bundle_sources(cleaned, fuser.modules, getattr(fuser, "entry_modules", None))]

--- a/tests/examples/pyminify.pymini.py
+++ b/tests/examples/pyminify.pymini.py
@@ -1,23 +1,22 @@
 def a(event,context):
- c='RequestType';d='PhysicalResourceId';e='None';f='Status';g='SUCCESS';h='Tags';i='OldResourceProperties';l.info(event);j,k,m,n,o,p,q,r,s=(event,create_cert,add_tags,validate,wait_for_issuance,context,send,reinvoke,acm)
+ l.info(event)
  try:
-  a=hashlib.new('md5',(j['RequestId']+j['StackId']).encode()).hexdigest();b=j['ResourceProperties']
-  if j[c]=='Create':
-   j[d]=e;j[d]=k(b,a);m(j[d],b);n(j[d],b)
-   if o(j[d],p):j[f]=g;return q(j)
-   else:return r(j,p)
-  elif j[c]=='Delete':
-   if j[d]!=e:s.delete_certificate(CertificateArn=j[d])
-   j[f]=g;return q(j)
-  elif j[c]=='Update':
-   if replace_cert(j):
-    j[d]=k(b,a);m(j[d],b);n(j[d],b)
-    if not o(j[d],p):return r(j,p)
+  a=hashlib.new('md5',(event['RequestId']+event['StackId']).encode()).hexdigest();b=event['ResourceProperties']
+  if event['RequestType']=='Create':
+   event['PhysicalResourceId']='None';event['PhysicalResourceId']=create_cert(b,a);add_tags(event['PhysicalResourceId'],b);validate(event['PhysicalResourceId'],b)
+   if wait_for_issuance(event['PhysicalResourceId'],context):event['Status']='SUCCESS';return send(event)
+   else:return reinvoke(event,context)
+  elif event['RequestType']=='Delete':
+   if event['PhysicalResourceId']!='None':acm.delete_certificate(CertificateArn=event['PhysicalResourceId'])
+   event['Status']='SUCCESS';return send(event)
+  elif event['RequestType']=='Update':
+   if replace_cert(event):
+    event['PhysicalResourceId']=create_cert(b,a);add_tags(event['PhysicalResourceId'],b);validate(event['PhysicalResourceId'],b)
+    if not wait_for_issuance(event['PhysicalResourceId'],context):return reinvoke(event,context)
    else:
-    if h in j[i]:s.remove_tags_from_certificate(CertificateArn=j[d],Tags=j[i][h])
-    m(j[d],b)
-   j[f]=g;return q(j)
+    if 'Tags' in event['OldResourceProperties']:acm.remove_tags_from_certificate(CertificateArn=event['PhysicalResourceId'],Tags=event['OldResourceProperties']['Tags'])
+    add_tags(event['PhysicalResourceId'],b)
+   event['Status']='SUCCESS';return send(event)
   else:raise RuntimeError('Unknown RequestType')
- except Exception as b:l.exception('');j[f]='FAILED';j['Reason']=str(b);return q(j)
- del (j,k,m,n,o,p,q,r,s)
+ except Exception as b:l.exception('');event['Status']='FAILED';event['Reason']=str(b);return send(event)
 handler=a

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,6 +91,7 @@ def test_minify_simplifies_returns():
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     assert cleaned == ["def f():return 1"]
@@ -108,6 +109,7 @@ def test_minify_handles_subscript_callables(tmp_path):
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     module_path = tmp_path / "module.py"
@@ -186,6 +188,7 @@ def test_minify_hoists_repeated_strings_inside_functions(tmp_path):
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     tree = ast.parse(cleaned[0])
@@ -224,6 +227,7 @@ def test_minify_hoists_repeated_strings_at_module_scope_without_leaking_helpers(
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     tree = ast.parse(cleaned[0])
@@ -267,6 +271,7 @@ def test_minify_skips_unprofitable_short_string_hoists_at_module_scope(tmp_path)
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     assert cleaned[0].count("'Foo'") == 2
@@ -300,6 +305,7 @@ def test_minify_hoists_repeated_strings_into_class_bodies_without_leaking_helper
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     tree = ast.parse(cleaned[0])
@@ -335,6 +341,7 @@ def test_minify_hoisted_strings_do_not_collide_with_lambda_parameters(tmp_path):
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     module_path = tmp_path / "module.py"
@@ -365,6 +372,7 @@ def test_minify_hoisted_strings_do_not_conflict_with_global_declarations(tmp_pat
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     module_path = tmp_path / "module.py"
@@ -397,6 +405,7 @@ def test_minify_aliases_repeated_names_within_single_statements(tmp_path):
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     tree = ast.parse(cleaned[0])
@@ -428,6 +437,7 @@ def test_minify_aliases_repeated_module_names_without_leaking_helpers(tmp_path):
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     tree = ast.parse(cleaned[0])
@@ -457,6 +467,50 @@ def test_minify_aliases_repeated_module_names_without_leaking_helpers(tmp_path):
     assert modules == ["main"]
 
 
+def test_minify_defaults_to_fast_profile_and_fast_false_restores_slow_pipeline(tmp_path):
+    cleaned, modules = minify(
+        py(
+            """
+            IMPORTANT_PUBLIC_NAME = 3
+            print("PhysicalResourceId", "PhysicalResourceId", IMPORTANT_PUBLIC_NAME, IMPORTANT_PUBLIC_NAME)
+            """
+        ),
+        "main",
+        keep_global_variables=True,
+        keep_module_names=True,
+    )
+    slow_cleaned, _ = minify(
+        py(
+            """
+            IMPORTANT_PUBLIC_NAME = 3
+            print("PhysicalResourceId", "PhysicalResourceId", IMPORTANT_PUBLIC_NAME, IMPORTANT_PUBLIC_NAME)
+            """
+        ),
+        "main",
+        keep_global_variables=True,
+        keep_module_names=True,
+        fast=False,
+    )
+
+    assert cleaned[0].count("PhysicalResourceId") == 2
+    assert "del(" not in cleaned[0]
+    assert slow_cleaned[0].count("PhysicalResourceId") == 1
+    assert "del" in slow_cleaned[0]
+
+    module_path = tmp_path / "module.py"
+    module_path.write_text(cleaned[0], encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "PhysicalResourceId PhysicalResourceId 3 3\n"
+    assert modules == ["main"]
+
+
 def test_minify_preserves_global_names_without_breaking_shadowed_locals(tmp_path):
     cleaned, modules = minify(
         py(
@@ -473,6 +527,7 @@ def test_minify_preserves_global_names_without_breaking_shadowed_locals(tmp_path
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     module_path = tmp_path / "module.py"
@@ -1524,6 +1579,7 @@ def test_minify_keeps_future_imports_before_hoisted_helpers(tmp_path):
         "main",
         keep_global_variables=True,
         keep_module_names=True,
+        fast=False,
     )
 
     tree = ast.parse(cleaned[0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,6 +348,47 @@ def test_cli_can_rename_arguments_when_requested(tmp_path):
     assert execution.stdout == "3\n"
 
 
+def test_cli_defaults_to_fast_profile_and_slow_opt_in_restores_extra_passes(tmp_path):
+    source_dir = tmp_path / "src"
+    output_dir = tmp_path / "out"
+    slow_output_dir = tmp_path / "out-slow"
+    source_dir.mkdir()
+    write_py(
+        source_dir / "main.py",
+        """
+        IMPORTANT_PUBLIC_NAME = 3
+        print("PhysicalResourceId", "PhysicalResourceId", IMPORTANT_PUBLIC_NAME, IMPORTANT_PUBLIC_NAME)
+        """,
+    )
+
+    result = run_cli(
+        "package",
+        str(source_dir),
+        "-o",
+        str(output_dir),
+    )
+    slow_result = run_cli(
+        "package",
+        str(source_dir),
+        "--slow",
+        "-o",
+        str(slow_output_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert slow_result.returncode == 0, slow_result.stderr
+    output = (output_dir / "main.py").read_text(encoding="utf-8")
+    slow_output = (slow_output_dir / "main.py").read_text(encoding="utf-8")
+    assert output.count("PhysicalResourceId") == 2
+    assert "del(" not in output
+    assert slow_output.count("PhysicalResourceId") == 1
+    assert "del" in slow_output
+
+    execution = run_python_file(output_dir / "main.py")
+    assert execution.returncode == 0, execution.stderr
+    assert execution.stdout == "PhysicalResourceId PhysicalResourceId 3 3\n"
+
+
 def test_cli_package_mode_supports_relative_star_reexports(tmp_path):
     source_dir = tmp_path / "src"
     output_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary

Make the faster compression profile the default for both the Python API and CLI, while keeping the slower full pipeline available as an explicit opt-in.

## What Changed

- changed `minify()` to default to `fast=True`
- changed the CLI to default to the fast profile and added `--slow` for the full pipeline
- kept the reserved-name cache improvement in place for the shared path
- updated tests to pin `fast=False` only where they specifically validate the slower hoisting and aliasing passes
- refreshed the checked-in example output and benchmark harness/docs to reflect the new profile split

## Why

The previous default paid a meaningful runtime cost for two optional passes that are not consistently beneficial. On the checked-in fixtures, the fast path is materially quicker, and the slower path is not reliably smaller on larger packages.

## Impact

- default `pymini` runs are faster without any flags
- users who want the old full pipeline can still get it with `--slow` or `fast=False`
- benchmark docs now distinguish default-speed behavior from the slower opt-in pipeline

## Validation

- `.venv/bin/pytest`
- refreshed local benchmark measurements used in `benchmarks/README.md`

## Notes

The slower profile still helps some smaller or targeted inputs, but it can also produce slightly larger output on fixtures like `click` and `pytest`, so the PR avoids presenting it as a universal "best compression" mode.